### PR TITLE
maint: add basic README, docker compose and kubernetes manifests

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,8 +1,6 @@
-export KEYCLOAK_URL=""
-export NEXT_PUBLIC_BASE_KEYCLOAK_URL=""
-export CLIENT_ID=""
-export SECRET=""
-export LOGOUT_REDIRECT_URL=""
-export NEXTAUTH_URL=""
-export NEXTAUTH_SECRET=""
-export FEDERATED_CATALOGUE_API=""
+# App env
+export BATCH_SIZE=40
+# Docker
+export MARKETPLACE_IMAGETAG="dev"
+# Kubernetes
+export PUBLIC_NODE_DOMAIN="sedimark.ari-energy.eu"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:18-alpine AS deps
+FROM node:20-alpine AS deps
 
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN apk add --no-cache bind-tools libc6-compat && \
     npm install
 
-FROM node:18-alpine as builder
+FROM node:20-alpine as builder
 
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# marketplace-frontend
-The frontend of the Sedimark marketplace
+# Marketplace frontend
+
+This repository contains the frontend of the Sedimark marketplace, a web application to 
+help Sedimark participants to publish, discover and consume offerings in the Sedimark 
+catalogue.
+
+## Getting started
+
+### With Docker 
+
+You can run only the marketplace frontend using docker:
+
+```bash
+docker run -d -p 3000:3000 sedimark/marketplace-frontend:dev
+```
+
+### With Docker Compose
+
+To spawn a marketplace frontend instance together with its dependencies:
+
+```bash
+export MARKETPLACE_IMAGETAG="dev"
+docker-compose up
+```
+
+### In Kubernetes
+
+Some kubernetes manifests are provides in the `kubernetes` directory. The ingress manifest 
+assumes that Traefik is used as the ingress controller, and that a middleware named 
+`traefik-chain-oauth` is available to handle the OAuth2 authentication. Feel free to 
+adapt the ingress manifest to your needs.
+
+Prior to the deployment, export the necessary environment variables:
+
+```bash
+# App env
+export BATCH_SIZE=40
+# Kubernetes
+export PUBLIC_NODE_DOMAIN="sedimark.ari-energy.eu"
+export MARKETPLACE_IMAGETAG="dev"
+```
+
+You can now apply the Kubernetes manifests:
+
+```bash
+cat ./kubernetes/*.yaml | envsubst | kubectl apply -f -
+```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  marketplace:
+    image: ghcr.io/sedimark/marketplace-frontend:${MARKETPLACE_IMAGETAG}
+    container_name: marketplace-frontend
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - BATCH_SIZE=40

--- a/kubernetes/000-marketplace-frontend-namespace.yaml
+++ b/kubernetes/000-marketplace-frontend-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: marketplace-frontend
+  labels:
+    name: marketplace-frontend
+---
+

--- a/kubernetes/005-marketplace-frontend-secret.yaml
+++ b/kubernetes/005-marketplace-frontend-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: marketplace-frontend-secret
+  namespace: marketplace-frontend
+type: Opaque
+stringData:
+  .env.production: |
+    BATCH_SIZE="${BATCH_SIZE}"
+---
+

--- a/kubernetes/020-marketplace-frontend-deployment.yaml
+++ b/kubernetes/020-marketplace-frontend-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketplace-frontend
+  namespace: marketplace-frontend
+  labels:
+    app: marketplace-frontend
+spec:
+  selector:
+    matchLabels:
+      app: marketplace-frontend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: marketplace-frontend
+    spec:
+      containers:
+      - name: marketplace-frontend
+        image: ghcr.io/sedimark/marketplace-frontend:${MARKETPLACE_IMAGETAG}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+          name: marketplace
+        volumeMounts:
+        - name: marketplace-frontend-secret
+          mountPath: /app/.env.production
+          subPath: .env.production
+      volumes:
+        - name: marketplace-frontend-secret
+          secret:
+            secretName: marketplace-frontend-secret
+      restartPolicy: Always
+---
+

--- a/kubernetes/030-marketplace-frontend-service.yaml
+++ b/kubernetes/030-marketplace-frontend-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: marketplace-frontend
+  namespace: marketplace-frontend
+spec:
+  selector:
+    app: marketplace-frontend
+  type: ClusterIP
+  ports:
+  - name: marketplace
+    protocol: TCP
+    port: 3000
+    targetPort: 3000
+---
+

--- a/kubernetes/040-marketplace-frontend-ingress.yaml
+++ b/kubernetes/040-marketplace-frontend-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: marketplace-frontend-ingress
+  namespace: marketplace-frontend
+  annotations:
+    traefik.ingress.kubernetes.io/router.tls.certresolver: default
+    traefik.ingress.kubernetes.io/router.entrypoints: web, websecure
+    traefik.ingress.kubernetes.io/router.middlewares: kube-system-traefik-chain-oauth@kubernetescrd
+spec:
+  rules:
+  - host: marketplace.${PUBLIC_NODE_DOMAIN}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: marketplace-frontend
+            port:
+              number: 3000
+---
+

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -3,9 +3,6 @@
  *
  * @typedef {Object} Settings
  * @property {number} batchSize - The total of items per page.
- * @property {URL} federatedCatalogueApi - The URL for the federated catalogue API.
- * @property {URL} federatedCatalogueProviders - The URL for the federated catalogue providers API.
- * @property {URL} federatedCatalogueFilters - The URL for the federated catalogue filters API.
  */
 
 /**
@@ -14,10 +11,7 @@
  * @type {Settings}
  */
 const settings = {
-  batchSize: process.env.BATCH_SIZE ?? 40,
-  federatedCatalogueApi: new URL('/query_page', process.env.FEDERATED_CATALOGUE_API),
-  federatedCatalogueProviders: new URL('/api/providers', process.env.FEDERATED_CATALOGUE_API),
-  federatedCatalogueFilters: new URL('/api/filters-data', process.env.FEDERATED_CATALOGUE_API)
+  batchSize: process.env.BATCH_SIZE ?? 40
 }
 Object.freeze(settings)
 


### PR DESCRIPTION
Hi there! This small PR adds a docker compose file (ultra basic, since no backend components has been integrated yet) as well as some kubernetes manifests to deploy the marketplace frontend. The README has been subsequently updated to explain how to use these resources.
