### PR TITLE
Error Handling on services (broker, catalogue & recommender)

### DIFF
--- a/src/app/catalogue/[offeringId]/components/Recommender.jsx
+++ b/src/app/catalogue/[offeringId]/components/Recommender.jsx
@@ -1,24 +1,36 @@
 import Link from 'next/link'
 import RecommenderItem from './RecommenderItem'
+import { Alert } from 'flowbite-react'
+import { TbAlertSquareFilled } from 'react-icons/tb'
 
 function Recommender ({ recommendations }) {
   return (
     <div className='bg-white w-3/3 m-5 mr-10 p-5 rounded-md'>
-      <h2 className='font-bold text-2xl'>You may also like...</h2>
-      <div className='flex gap-4 overflow-x-auto p-4 w-full'>
-        {recommendations.map((recommendation, index) => {
-          return (
-            <Link key={`${recommendation.title.value}-${recommendation.created.value}-${index + 1}`} href={`/catalogue/${btoa(recommendation.offering.value)}`}>
-              <RecommenderItem
-                vc={recommendation}
-                providerName={recommendation.publisher.value}
-                price={recommendation?.price ?? 0}
-                color='bg-sedimark-light-blue bg-red'
-              />
-            </Link>
-          )
-        })}
-      </div>
+      {!recommendations?.error &&
+        <>
+          <h2 className='font-bold text-2xl'>You may also like...</h2>
+          <div className='flex gap-4 overflow-x-auto p-4 w-full'>
+            {recommendations.map((recommendation, index) => {
+              return (
+                <Link key={`${recommendation.title.value}-${recommendation.created.value}-${index + 1}`} href={`/catalogue/${btoa(recommendation.offering.value)}`}>
+                  <RecommenderItem
+                    vc={recommendation}
+                    providerName={recommendation.publisher.value}
+                    price={recommendation?.price ?? 0}
+                    color='bg-sedimark-light-blue bg-red'
+                  />
+                </Link>
+              )
+            })}
+          </div>
+        </>}
+      {recommendations?.error &&
+        <>
+          <Alert color='failure' icon={TbAlertSquareFilled}>
+            {/* While in this case, the text is static, can be changed depending on the content/code from the error */}
+            <span className='font-bold text-2xl'>Recommender service is not responding. Please, try again.</span>
+          </Alert>
+        </>}
     </div>
   )
 }

--- a/src/app/catalogue/[offeringId]/components/Recommender.jsx
+++ b/src/app/catalogue/[offeringId]/components/Recommender.jsx
@@ -5,9 +5,9 @@ import { TbAlertSquareFilled } from 'react-icons/tb'
 
 function Recommender ({ recommendations }) {
   return (
-    <div className='bg-white w-3/3 m-5 mr-10 p-5 rounded-md'>
+    <>
       {!recommendations?.error &&
-        <>
+        <div className='bg-white w-3/3 m-5 mr-10 p-5 rounded-md'>
           <h2 className='font-bold text-2xl'>You may also like...</h2>
           <div className='flex gap-4 overflow-x-auto p-4 w-full'>
             {recommendations.map((recommendation, index) => {
@@ -23,7 +23,7 @@ function Recommender ({ recommendations }) {
               )
             })}
           </div>
-        </>}
+        </div>}
       {recommendations?.error &&
         <>
           <Alert color='failure' icon={TbAlertSquareFilled}>
@@ -31,7 +31,7 @@ function Recommender ({ recommendations }) {
             <span className='font-bold text-2xl'>Recommender service is not responding. Please, try again.</span>
           </Alert>
         </>}
-    </div>
+    </>
   )
 }
 export default Recommender

--- a/src/app/catalogue/components/ResultsPane.js
+++ b/src/app/catalogue/components/ResultsPane.js
@@ -1,8 +1,9 @@
 'use client'
-import { Button } from 'flowbite-react'
+import { Button, Alert } from 'flowbite-react'
 import { useEffect, useState, useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { HiOutlineX } from 'react-icons/hi'
+import { TbAlertSquareFilled } from 'react-icons/tb'
 import CustomPagination from '@/components/pagination/Pagination'
 import LoadingCard from '@/app/catalogue/components/LoadingCard'
 import CatalogueSideBar from './SideBar'
@@ -67,7 +68,7 @@ export default function ResultsPane ({
 
   // Update state when data is fetched
   useEffect(() => {
-    if (data) {
+    if (data && !data?.error) {
       window.scrollTo(0, 0, 'smooth')
       setLoading(false)
       setVcs(data.slice(0, settings.batchSize))
@@ -115,7 +116,7 @@ export default function ResultsPane ({
               <HiOutlineX className='ml-2' />
             </span>
           </Button>}
-        {!loading && !results.length && data && (
+        {!loading && !results.length && data && !data?.error && (
           <div className='flex flex-col w-full gap-4 p-4 bg-gray-50'>
             <div className='w-full gap-4 p-6 text-center bg-white border border-gray-200 rounded-lg shadow'>
               <h5 className='mb-2 text-2xl font-bold tracking-tight text-gray-900'>Whoops! There are no results matching your filters criteria.</h5>
@@ -128,6 +129,14 @@ export default function ResultsPane ({
             <p className='flex justify-end pr-4 pt-2.5 text-xs'> {(currentPage * settings.batchSize) - (settings.batchSize - 1)} - {currentPage * settings.batchSize} of over {totalVcs} results</p>
             <ResultsList results={vcs} />
             <CustomPagination totalPages={totalPagesToDisplay === 0 ? 1 : totalPagesToDisplay} currentPage={currentPage} setCurrentPage={setCurrentPage} />
+          </div>
+        )}
+        {!loading && !results.length && data?.error && (
+          <div className='flex flex-col w-full gap-4 p-4 bg-gray-50'>
+            <Alert color='failure' icon={TbAlertSquareFilled}>
+              {/* While in this case, the text is static, can be changed depending on the content/code from the error */}
+              <span className='font-bold text-xl'>Catalogue service is not responding. Please, try again.</span>
+            </Alert>
           </div>
         )}
       </div>

--- a/src/app/catalogue/components/ResultsPane.js
+++ b/src/app/catalogue/components/ResultsPane.js
@@ -109,6 +109,14 @@ export default function ResultsPane ({
         <LoadingCard />
       )}
       <div className='flex flex-col w-full bg-gray-50'>
+        {!loading && data?.error && (
+          <div className='flex flex-col w-full gap-4 p-4 bg-gray-50'>
+            <Alert color='failure' icon={TbAlertSquareFilled}>
+              {/* While in this case, the text is static, can be changed depending on the content/code from the error */}
+              <span className='font-bold text-xl'>Catalogue service is not responding. Please, try again.</span>
+            </Alert>
+          </div>
+        )}
         {!loading && query &&
           <Button className='pl-4 m-4 mb-0 w-fit ' outline pill size='xs' color='gray' onClick={() => setQuery('')}>
             <span className='flex items-center '>
@@ -129,14 +137,6 @@ export default function ResultsPane ({
             <p className='flex justify-end pr-4 pt-2.5 text-xs'> {(currentPage * settings.batchSize) - (settings.batchSize - 1)} - {currentPage * settings.batchSize} of over {totalVcs} results</p>
             <ResultsList results={vcs} />
             <CustomPagination totalPages={totalPagesToDisplay === 0 ? 1 : totalPagesToDisplay} currentPage={currentPage} setCurrentPage={setCurrentPage} />
-          </div>
-        )}
-        {!loading && !results.length && data?.error && (
-          <div className='flex flex-col w-full gap-4 p-4 bg-gray-50'>
-            <Alert color='failure' icon={TbAlertSquareFilled}>
-              {/* While in this case, the text is static, can be changed depending on the content/code from the error */}
-              <span className='font-bold text-xl'>Catalogue service is not responding. Please, try again.</span>
-            </Alert>
           </div>
         )}
       </div>

--- a/src/app/catalogue/components/SideBar.js
+++ b/src/app/catalogue/components/SideBar.js
@@ -56,25 +56,28 @@ export default function CatalogueSideBar ({
           </Button>
         )}
         <ListGroup className='w-48 h-80 overflow-auto '>
-          {providers.map((provider) => (
-            <ListGroup.Item
-              key={`provider-${provider}-filter`}
-              className='flex items-center text-left cursor-pointer last:border-b-0'
-              onClick={() => {
-                handleProviderChange(provider)
-              }}
-            >
-              <Checkbox
-                id={provider}
-                className='mr-2'
-                checked={selectedProviders.includes(provider)}
-                readOnly
-              />
-              <Label className='py-1 text-left'>
-                {provider}
-              </Label>
-            </ListGroup.Item>
-          ))}
+          {!providers?.error &&
+            <>
+              {providers.map((provider) => (
+                <ListGroup.Item
+                  key={`provider-${provider}-filter`}
+                  className='flex items-center text-left cursor-pointer last:border-b-0'
+                  onClick={() => {
+                    handleProviderChange(provider)
+                  }}
+                >
+                  <Checkbox
+                    id={provider}
+                    className='mr-2'
+                    checked={selectedProviders.includes(provider)}
+                    readOnly
+                  />
+                  <Label className='py-1 text-left'>
+                    {provider}
+                  </Label>
+                </ListGroup.Item>
+              ))}
+            </>}
         </ListGroup>
         <div className='text-lg font-semibold'>Keywords</div>
         {selectedKeywords.length > 0 && (
@@ -91,23 +94,26 @@ export default function CatalogueSideBar ({
 
         <div>
           <ListGroup className='w-48 h-64 overflow-auto'>
-            {keywords.map((keyword, index) => (
-              <ListGroup.Item
-                key={`keyword-${keyword}-filter` + index}
-                className='flex items-center cursor-pointer last:border-b-0'
-                onClick={() => handleKeywordChange(keyword)}
-              >
-                <Checkbox
-                  id={keyword}
-                  className='mr-2'
-                  checked={selectedKeywords.includes(keyword)}
-                  readOnly
-                />
-                <Label className='py-1 text-left'>
-                  {keyword}
-                </Label>
-              </ListGroup.Item>
-            ))}
+            {!keywords?.error &&
+              <>
+                {keywords.map((keyword, index) => (
+                  <ListGroup.Item
+                    key={`keyword-${keyword}-filter` + index}
+                    className='flex items-center cursor-pointer last:border-b-0'
+                    onClick={() => handleKeywordChange(keyword)}
+                  >
+                    <Checkbox
+                      id={keyword}
+                      className='mr-2'
+                      checked={selectedKeywords.includes(keyword)}
+                      readOnly
+                    />
+                    <Label className='py-1 text-left'>
+                      {keyword}
+                    </Label>
+                  </ListGroup.Item>
+                ))}
+              </>}
           </ListGroup>
         </div>
       </div>

--- a/src/app/catalogue/utils/paginationHelpers.js
+++ b/src/app/catalogue/utils/paginationHelpers.js
@@ -12,7 +12,9 @@
 export function calculateItemsPerPage (currentPage, settings, data, setVcs) {
   const startIndex = (currentPage - 1) * settings.batchSize
   const endIndex = (currentPage * settings.batchSize) > data.total ? data.total : currentPage * settings.batchSize
-  setVcs(data.slice(startIndex, endIndex))
+  if (!data?.error) {
+    setVcs(data.slice(startIndex, endIndex))
+  }
 }
 
 /**

--- a/src/utils/broker.js
+++ b/src/utils/broker.js
@@ -1,5 +1,5 @@
 import settings from '@/utils/settings'
-import { fetchData } from './helpers/fetchData'
+import { fetchData } from '@/utils/helpers/fetchData'
 const contextLink = '<https://sedimark.github.io/broker/jsonld-contexts/sedimark-compound.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
 
 // For now its the only interaction needed with the broker, may be expanded on the future?
@@ -17,7 +17,7 @@ export async function fetchAssetsFromBroker () {
     const data = await fetchData(url, options).then(response => response.json())
     return { data }
   } catch (error) {
-    // Here is the thing, server side fetch can't just throw an error, as it would "stop" the page (500 in our Nextjs)
+    // Will be 2 printed errors as there is a console.log on the fetchData helper, but as is server side can help us id the error.
     console.log('Error on broker!')
     console.log(error)
     return { error }

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -1,4 +1,5 @@
 import settings from '@/utils/settings'
+import { fetchData } from '@/utils/helpers/fetchData'
 
 const prefixes = `
     PREFIX http: <http://www.w3.org/2011/http#>
@@ -39,8 +40,15 @@ async function fetchFromCatalogue (sparQLQuery) {
     body: `query=${sparQLQuery}`
   }
   const url = `${settings.catalogueUrl}/catalogue/sparql`
-  const data = await fetch(url, options).then(response => response.json())
-  return data.results.bindings
+  try {
+    const data = await fetchData(url, options).then(response => response.json())
+    return data.results.bindings
+  } catch (error) {
+    // Will be 2 printed errors as there is a console.log on the fetchData helper, but as is server side can help us id the error.
+    console.log('Error on fetchFromCatalogue!')
+    console.log(error)
+    return { error }
+  }
 }
 
 function getSparQLOfferingQueryString (query, currentPage, batchSize = settings.batchSize) {
@@ -79,7 +87,7 @@ function getSparQLOfferingsCountQueryString () {
 export async function fetchOfferingsCount () {
   const sparQLQuery = getSparQLOfferingsCountQueryString()
   const data = await fetchFromCatalogue(sparQLQuery)
-  return data[0].count.value
+  return data[0]?.count.value
 }
 
 function getSparQLProvidersQueryString (query) {
@@ -118,7 +126,7 @@ function getSparQLParticipantsCountQueryString () {
 export async function fetchParticipantsCount () {
   const sparQLQuery = getSparQLParticipantsCountQueryString()
   const data = await fetchFromCatalogue(sparQLQuery)
-  return data[0].count.value
+  return data[0]?.count.value
 }
 
 function getSparQLKeywordsQueryString (query) {

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -107,8 +107,11 @@ function getSparQLProvidersQueryString (query) {
 export async function fetchProviders (query) {
   const sparQLQuery = getSparQLProvidersQueryString(query)
   const data = await fetchFromCatalogue(sparQLQuery)
-  const providers = data.map(prov => prov.publisher.value)
-  return providers
+  if (!data.error) {
+    const providers = data.map(prov => prov.publisher.value)
+    return providers
+  }
+  return data
 }
 
 function getSparQLParticipantsCountQueryString () {
@@ -147,8 +150,11 @@ function getSparQLKeywordsQueryString (query) {
 export async function fetchKeywords (query) {
   const sparQLQuery = getSparQLKeywordsQueryString(query)
   const data = await fetchFromCatalogue(sparQLQuery)
-  const keywords = data.map(binding => binding.keyword.value)
-  return keywords
+  if (!data.error) {
+    const keywords = data.map(binding => binding.keyword.value)
+    return keywords
+  }
+  return data
 }
 
 export async function fetchRecommendedOfferings (offeringIds) {

--- a/src/utils/errors/errorFormatter.js
+++ b/src/utils/errors/errorFormatter.js
@@ -31,9 +31,7 @@ export default function formatError (error) {
   return {
     message: 'An unexpected error occurred.',
     code: 'UNKNOWN_ERROR',
-    details: {
-      originalErrorMessage: error.message,
-      originalStack: error.stack
-    }
+      details: error.message,
+      stack: error.stack
   }
 }

--- a/src/utils/errors/errorFormatter.js
+++ b/src/utils/errors/errorFormatter.js
@@ -31,7 +31,7 @@ export default function formatError (error) {
   return {
     message: 'An unexpected error occurred.',
     code: 'UNKNOWN_ERROR',
-      details: error.message,
-      stack: error.stack
+    details: error.message,
+    stack: error.stack
   }
 }

--- a/src/utils/errors/errorFormatter.js
+++ b/src/utils/errors/errorFormatter.js
@@ -13,7 +13,10 @@ export default function formatError (error) {
     return {
       message: 'Network error. Please check your internet connection.',
       code: 'NETWORK_ERROR',
-      details: { error }
+      details: { 
+        originalErrorMessage: error.message,
+        originalStack: error.stack
+      }
     }
   }
 
@@ -21,7 +24,10 @@ export default function formatError (error) {
     return {
       message: 'URL defined to fetch failed.',
       code: 'URL_NOT_VALID',
-      details: { error }
+      details: { 
+        originalErrorMessage: error.message,
+        originalStack: error.stack
+      }
     }
   }
   // Same for other errors (parsing, ...)
@@ -29,6 +35,9 @@ export default function formatError (error) {
   return {
     message: 'An unexpected error occurred.',
     code: 'UNKNOWN_ERROR',
-    details: { error }
+    details: { 
+      originalErrorMessage: error.message,
+      originalStack: error.stack
+    }
   }
 }

--- a/src/utils/errors/errorFormatter.js
+++ b/src/utils/errors/errorFormatter.js
@@ -13,7 +13,15 @@ export default function formatError (error) {
     return {
       message: 'Network error. Please check your internet connection.',
       code: 'NETWORK_ERROR',
-      details: {}
+      details: { error }
+    }
+  }
+
+  if (error instanceof TypeError && error.message.includes('Failed to parse URL')) {
+    return {
+      message: 'URL defined to fetch failed.',
+      code: 'URL_NOT_VALID',
+      details: { error }
     }
   }
   // Same for other errors (parsing, ...)
@@ -21,6 +29,6 @@ export default function formatError (error) {
   return {
     message: 'An unexpected error occurred.',
     code: 'UNKNOWN_ERROR',
-    details: {}
+    details: { error }
   }
 }

--- a/src/utils/errors/errorFormatter.js
+++ b/src/utils/errors/errorFormatter.js
@@ -24,10 +24,8 @@ export default function formatError (error) {
     return {
       message: 'URL defined to fetch failed.',
       code: 'URL_NOT_VALID',
-      details: {
-        originalErrorMessage: error.message,
-        originalStack: error.stack
-      }
+      details: error.message,
+      stack: error.stack
     }
   }
   // Same for other errors (parsing, ...)

--- a/src/utils/errors/errorFormatter.js
+++ b/src/utils/errors/errorFormatter.js
@@ -13,7 +13,7 @@ export default function formatError (error) {
     return {
       message: 'Network error. Please check your internet connection.',
       code: 'NETWORK_ERROR',
-      details: { 
+      details: {
         originalErrorMessage: error.message,
         originalStack: error.stack
       }
@@ -24,7 +24,7 @@ export default function formatError (error) {
     return {
       message: 'URL defined to fetch failed.',
       code: 'URL_NOT_VALID',
-      details: { 
+      details: {
         originalErrorMessage: error.message,
         originalStack: error.stack
       }
@@ -35,7 +35,7 @@ export default function formatError (error) {
   return {
     message: 'An unexpected error occurred.',
     code: 'UNKNOWN_ERROR',
-    details: { 
+    details: {
       originalErrorMessage: error.message,
       originalStack: error.stack
     }

--- a/src/utils/errors/errorFormatter.js
+++ b/src/utils/errors/errorFormatter.js
@@ -13,10 +13,8 @@ export default function formatError (error) {
     return {
       message: 'Network error. Please check your internet connection.',
       code: 'NETWORK_ERROR',
-      details: {
-        originalErrorMessage: error.message,
-        originalStack: error.stack
-      }
+      details: error.message,
+      stack: error.stack
     }
   }
 

--- a/src/utils/helpers/fetchData.js
+++ b/src/utils/helpers/fetchData.js
@@ -16,8 +16,8 @@ export async function fetchData (url, options = {}) {
     return response
   } catch (error) {
     // Probably network or CORS errors
-    // Printing on server-side
-    console.log(error)
+    // As we already print on catch where it is, its commented, but in case of deep search for an error, left it here.
+    // console.log(error)
     throw formatError(error)
   }
 }

--- a/src/utils/recommender.js
+++ b/src/utils/recommender.js
@@ -1,5 +1,6 @@
 import settings from '@/utils/settings'
 import { fetchRecommendedOfferings } from '@/utils/catalogue'
+import { fetchData } from '@/utils/helpers/fetchData'
 
 export async function fetchQueryRecommendations (query, numRecommendations = settings.numRecommendations) {
   const options = {
@@ -11,9 +12,15 @@ export async function fetchQueryRecommendations (query, numRecommendations = set
     body: `{"text": "${query}", "k": ${numRecommendations}}`
   }
   const url = `${settings.recommenderUrl}/api/query`
-  const data = await fetch(url, options).then(response => response.json())
-
-  return fetchRecommendedOfferings(data.offering_ids)
+  try {
+    const data = await fetchData(url, options).then(response => response.json())
+    return fetchRecommendedOfferings(data.offering_ids)
+  } catch (error) {
+    // Will be 2 printed errors as there is a console.log on the fetchData helper, but as is server side can help us id the error.
+    console.log('Error on fetchQueryRecommendations!')
+    console.log(error)
+    return { error }
+  }
 }
 
 export async function fetchSimilarRecommendations (offeringId, numRecommendations = settings.numRecommendations) {
@@ -26,13 +33,20 @@ export async function fetchSimilarRecommendations (offeringId, numRecommendation
     body: `{"id": "${offeringId}", "k": ${numRecommendations}}`
   }
   const url = `${settings.recommenderUrl}/api/similar`
-  const res = await fetch(url, options)
-  const data = await res.json()
-  if (!res.ok) {
-    console.warn(`Warning: couldn't fetch similar recommendations for offering ${offeringId}: ${res.status} ${res.statusText} - ${JSON.stringify(data)}`)
-    console.warn('Skipping recommendations...')
-    return []
-  }
+  try {
+    const res = await fetchData(url, options)
+    const data = await res.json()
+    if (!res.ok) {
+      console.warn(`Warning: couldn't fetch similar recommendations for offering ${offeringId}: ${res.status} ${res.statusText} - ${JSON.stringify(data)}`)
+      console.warn('Skipping recommendations...')
+      return []
+    }
 
-  return fetchRecommendedOfferings(data.offering_ids)
+    return fetchRecommendedOfferings(data.offering_ids)
+  } catch (error) {
+    // Will be 2 printed errors as there is a console.log on the fetchData helper, but as is server side can help us id the error.
+    console.log('Error on fetchSimilarRecommendations!')
+    console.log(error)
+    return { error }
+  }
 }


### PR DESCRIPTION
# 📃Description
Integrates the **Error handling** WIP implemented on PR #48  into the Sedimark marketplace. 

The idea is quite defined on #49, but at the same time we not only need to catch errors (and categorize them for easier debugging) on the server side so the app just crashes, but to inform (when is possible) to the users of the app when the service its failing.

So this PR overhauls the calls to use the `fetchData` helper, so it uses the custom `ErrorFormatting`, and it makes that the server side fetch (usually called `services`) are always returning either `obj` `data` (the expected response) or `error`. But _ALWAYS_ `return` something, never let a function without a `try...catch` with a proper return on it, or `throw` an error.

# Dependencies
Well, to try the error catching, go from not having the URL of the services `undefined` on your `local.env`, or these services be unreachable.

# 🔑Key Features
### Error Handling

As discussed here:
- #49 

Added to the first Iteration of error handling the services *catalogue* & *recommender*.

As always, I tried to be as future proof as I can, while maintaining the "recomendations" from the Nextjs official docs.

## Next Steps
N/A

## 💡Ideas for future
Having the wrapper for error alerts?

# 🔒 Issues to close
- #49 
- #46
# Please review and provide feedback or suggestions for further improvements.