### PR TITLE
0.8v Filters Side-Bar

### DIFF
--- a/src/app/catalogue/components/Catalogue.js
+++ b/src/app/catalogue/components/Catalogue.js
@@ -10,11 +10,13 @@ import Recommender from '../[offeringId]/components/Recommender'
  *
  * @returns {JSX.Element} The Catalogue component.
  */
-export default function Catalogue ({ query, currentPage }) {
+export default function Catalogue ({ query, keywords, providers, currentPage }) {
   return (
     <>
       <ResultsPane
         query={query}
+        keywords={keywords}
+        providers={providers}
         currentPage={currentPage}
       />
       <Recommender query={query} />

--- a/src/app/catalogue/components/ResultsList.js
+++ b/src/app/catalogue/components/ResultsList.js
@@ -13,8 +13,8 @@ import { TbAlertSquareFilled } from 'react-icons/tb'
  *
  * @returns {JSX.Element} A JSX element representing the rendered list of VCs.
  */
-export default async function ResultsList ({ query, currentPage }) {
-  const data = await fetchOfferings(query, currentPage)
+export default async function ResultsList ({ query, keywords, providers, currentPage }) {
+  const data = await fetchOfferings(query, keywords, providers, currentPage)
   return (
     <>
       {!data && ( // Error during fetch (potentially Catalogue unavailable)

--- a/src/app/catalogue/components/ResultsPane.js
+++ b/src/app/catalogue/components/ResultsPane.js
@@ -1,11 +1,11 @@
 import { Suspense } from 'react'
 import CustomPagination from '@/components/pagination/Pagination'
 import LoadingCard from '@/app/catalogue/components/LoadingCard'
-// import CatalogueSideBar from './SideBar'
+import CatalogueSideBar from './SideBar'
 import ResultsList from './ResultsList'
 import settings from '@/utils/settings'
 import { calculateTotalPages } from '../utils/paginationHelpers'
-import { fetchOfferingsCount } from '@/utils/catalogue'
+import { fetchKeywords, fetchOfferingsCount, fetchProviders } from '@/utils/catalogue'
 
 /**
  * Component responsible for rendering a pane to display catalogue query results.
@@ -15,25 +15,23 @@ import { fetchOfferingsCount } from '@/utils/catalogue'
  * @param {Array} props.keywords - The list of keywords.
  * @returns {JSX.Element} A JSX element representing the rendered pane of results.
  */
-export default async function ResultsPane ({ query, currentPage }) {
-  const dataCount = await fetchOfferingsCount(query)
+export default async function ResultsPane ({ query, keywords, providers, currentPage }) {
+  const dataCount = await fetchOfferingsCount(query, keywords, providers)
   const totalPages = calculateTotalPages(dataCount, settings.batchSize)
+  const keywordsList = await fetchKeywords(query)
+  const providersList = await fetchProviders(query)
 
   return (
     <div className='flex flex-row bg-gray-50'>
-      {/* <CatalogueSideBar
-        providers={providers}
-        keywords={keywords}
-        selectedProviders={selectedProviders}
-        setSelectedProviders={setSelectedProviders}
-        selectedKeywords={selectedKeywords}
-        setSelectedKeywords={setSelectedKeywords}
-      /> */}
+      <CatalogueSideBar
+        providersList={providersList}
+        keywordsList={keywordsList}
+      />
       <div className='flex flex-col w-full bg-gray-50'>
         <div className='w-full bg-gray-50 '>
           <p className='flex justify-end pr-4 pt-2.5 text-xs'> {(currentPage * settings.batchSize) - (settings.batchSize - 1)} - {currentPage * settings.batchSize} of over {dataCount} results</p>
-          <Suspense fallback={<LoadingCard />} key={query + currentPage}>
-            <ResultsList query={query} currentPage={currentPage} dataCount={dataCount} totalPages={totalPages} />
+          <Suspense fallback={<LoadingCard />} key={query + keywords + providers + currentPage}>
+            <ResultsList query={query} keywords={keywords} providers={providers} currentPage={currentPage} dataCount={dataCount} totalPages={totalPages} />
           </Suspense>
           <CustomPagination totalPages={totalPages} currentPage={currentPage} />
         </div>

--- a/src/app/catalogue/components/SideBar.js
+++ b/src/app/catalogue/components/SideBar.js
@@ -75,8 +75,6 @@ export default function CatalogueSideBar ({
         >Apply Filters
         </Button>
         <div className='text-lg font-semibold'>Providers</div>
-
-        {selectedProviders.length > 0 && (
           <Button
             size='xs'
             className='px-5 py-1 mb-2 text-sm text-gray-900 bg-gray-100 border border-gray-200 rounded-lg me-2 focus:outline-none enabled:hover:bg-gray-200 hover:text-gray focus:z-10 focus:ring-4 focus:ring-gray-100'
@@ -86,7 +84,6 @@ export default function CatalogueSideBar ({
           >
             Clear all Providers
           </Button>
-        )}
         <ListGroup className='w-48 h-80 overflow-auto '>
           {!providersList?.error &&
             <>
@@ -112,7 +109,6 @@ export default function CatalogueSideBar ({
             </>}
         </ListGroup>
         <div className='text-lg font-semibold'>Keywords</div>
-        {selectedKeywords.length > 0 && (
           <Button
             size='xs'
             className='px-5 py-1 mb-2 text-sm text-gray-900 bg-gray-100 border border-gray-200 rounded-lg me-2 focus:outline-none enabled:hover:bg-gray-200 hover:text-gray focus:z-10 focus:ring-4 focus:ring-gray-100'
@@ -122,8 +118,6 @@ export default function CatalogueSideBar ({
           >
             Clear all keywords
           </Button>
-        )}
-
         <div>
           <ListGroup className='w-48 h-64 overflow-auto'>
             {!keywordsList?.error &&

--- a/src/app/catalogue/components/SideBar.js
+++ b/src/app/catalogue/components/SideBar.js
@@ -1,6 +1,7 @@
 'use client'
 import { Button, Checkbox, Label, ListGroup } from 'flowbite-react'
-
+import { useState } from 'react'
+import { usePathname, useSearchParams, useRouter } from 'next/navigation'
 /**
  * Component responsible for rendering a sidebar with filtering options for the catalogue results.
  * It also allows the user to filter the catalogue by providers and keywords.
@@ -15,13 +16,15 @@ import { Button, Checkbox, Label, ListGroup } from 'flowbite-react'
  * @returns {JSX.Element} A JSX element representing the rendered sidebar.
  */
 export default function CatalogueSideBar ({
-  providers,
-  keywords,
-  selectedProviders,
-  setSelectedProviders,
-  selectedKeywords,
-  setSelectedKeywords
+  providersList,
+  keywordsList
 }) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const [selectedKeywords, setSelectedKeywords] = useState([])
+  const [selectedProviders, setSelectedProviders] = useState([])
+
   const handleProviderChange = (provider) => {
     const index = selectedProviders.indexOf(provider)
     if (index > -1) {
@@ -39,11 +42,40 @@ export default function CatalogueSideBar ({
       setSelectedKeywords([...selectedKeywords, keyword])
     }
   }
+
+  const createPageURL = (keywords, providers) => {
+    const params = new URLSearchParams(searchParams)
+    // Reset page & clear
+    params.set('page', '1')
+    params.delete('keywords')
+    params.delete('providers')
+    keywords.forEach(element => {
+      params.append('keywords', element.toString())
+    })
+    providers.forEach(element => {
+      params.append('providers', element.toString())
+    })
+    return `${pathname}?${params.toString()}`
+  }
+
+  const applyFilter = (keywords, providers) => {
+    router.push(createPageURL(keywords, providers))
+  }
+
   return (
     <div className='flex flex-col gap-4 p-2 bg-gray-50'>
       <div className='flex flex-col gap-2 p-3'>
         <div className='text-2xl font-semibold'>Filters</div>
+        <Button
+          size='xs'
+          className='px-5 py-1 mb-2 text-sm'
+          onClick={() => {
+            applyFilter(selectedKeywords, selectedProviders)
+          }}
+        >Apply Filters
+        </Button>
         <div className='text-lg font-semibold'>Providers</div>
+
         {selectedProviders.length > 0 && (
           <Button
             size='xs'
@@ -56,9 +88,9 @@ export default function CatalogueSideBar ({
           </Button>
         )}
         <ListGroup className='w-48 h-80 overflow-auto '>
-          {!providers?.error &&
+          {!providersList?.error &&
             <>
-              {providers.map((provider) => (
+              {providersList.map((provider) => (
                 <ListGroup.Item
                   key={`provider-${provider}-filter`}
                   className='flex items-center text-left cursor-pointer last:border-b-0'
@@ -94,9 +126,9 @@ export default function CatalogueSideBar ({
 
         <div>
           <ListGroup className='w-48 h-64 overflow-auto'>
-            {!keywords?.error &&
+            {!keywordsList?.error &&
               <>
-                {keywords.map((keyword, index) => (
+                {keywordsList.map((keyword, index) => (
                   <ListGroup.Item
                     key={`keyword-${keyword}-filter` + index}
                     className='flex items-center cursor-pointer last:border-b-0'

--- a/src/app/catalogue/components/SideBar.js
+++ b/src/app/catalogue/components/SideBar.js
@@ -21,9 +21,10 @@ export default function CatalogueSideBar ({
 }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const params = new URLSearchParams(searchParams)
   const router = useRouter()
-  const [selectedKeywords, setSelectedKeywords] = useState([])
-  const [selectedProviders, setSelectedProviders] = useState([])
+  const [selectedKeywords, setSelectedKeywords] = useState(params.getAll('keywords'))
+  const [selectedProviders, setSelectedProviders] = useState(params.getAll('providers'))
 
   const handleProviderChange = (provider) => {
     const index = selectedProviders.indexOf(provider)
@@ -44,7 +45,6 @@ export default function CatalogueSideBar ({
   }
 
   const createPageURL = (keywords, providers) => {
-    const params = new URLSearchParams(searchParams)
     // Reset page & clear
     params.set('page', '1')
     params.delete('keywords')

--- a/src/app/catalogue/components/SideBar.js
+++ b/src/app/catalogue/components/SideBar.js
@@ -75,15 +75,15 @@ export default function CatalogueSideBar ({
         >Apply Filters
         </Button>
         <div className='text-lg font-semibold'>Providers</div>
-          <Button
-            size='xs'
-            className='px-5 py-1 mb-2 text-sm text-gray-900 bg-gray-100 border border-gray-200 rounded-lg me-2 focus:outline-none enabled:hover:bg-gray-200 hover:text-gray focus:z-10 focus:ring-4 focus:ring-gray-100'
-            onClick={() => {
-              setSelectedProviders([])
-            }}
-          >
-            Clear all Providers
-          </Button>
+        <Button
+          size='xs'
+          className='px-5 py-1 mb-2 text-sm text-gray-900 bg-gray-100 border border-gray-200 rounded-lg me-2 focus:outline-none enabled:hover:bg-gray-200 hover:text-gray focus:z-10 focus:ring-4 focus:ring-gray-100'
+          onClick={() => {
+            setSelectedProviders([])
+          }}
+        >
+          Clear all Providers
+        </Button>
         <ListGroup className='w-48 h-80 overflow-auto '>
           {!providersList?.error &&
             <>
@@ -109,15 +109,15 @@ export default function CatalogueSideBar ({
             </>}
         </ListGroup>
         <div className='text-lg font-semibold'>Keywords</div>
-          <Button
-            size='xs'
-            className='px-5 py-1 mb-2 text-sm text-gray-900 bg-gray-100 border border-gray-200 rounded-lg me-2 focus:outline-none enabled:hover:bg-gray-200 hover:text-gray focus:z-10 focus:ring-4 focus:ring-gray-100'
-            onClick={() => {
-              setSelectedKeywords([])
-            }}
-          >
-            Clear all keywords
-          </Button>
+        <Button
+          size='xs'
+          className='px-5 py-1 mb-2 text-sm text-gray-900 bg-gray-100 border border-gray-200 rounded-lg me-2 focus:outline-none enabled:hover:bg-gray-200 hover:text-gray focus:z-10 focus:ring-4 focus:ring-gray-100'
+          onClick={() => {
+            setSelectedKeywords([])
+          }}
+        >
+          Clear all keywords
+        </Button>
         <div>
           <ListGroup className='w-48 h-64 overflow-auto'>
             {!keywordsList?.error &&

--- a/src/app/catalogue/page.js
+++ b/src/app/catalogue/page.js
@@ -11,12 +11,14 @@ import Catalogue from './components/Catalogue'
  */
 export default function Page ({ searchParams }) {
   const query = searchParams?.query || ''
+  const keywords = searchParams?.keywords || []
+  const providers = searchParams?.providers || ''
   const currentPage = Number(searchParams?.page) || 1
 
   return (
     <div className='bg-sedimark-dark-deep-blue'>
       <SearchBar />
-      <Catalogue query={query} currentPage={currentPage} />
+      <Catalogue query={query} keywords={keywords} providers={providers} currentPage={currentPage} />
     </div>
   )
 }

--- a/src/app/catalogue/page.js
+++ b/src/app/catalogue/page.js
@@ -11,7 +11,7 @@ import Catalogue from './components/Catalogue'
  */
 export default function Page ({ searchParams }) {
   const query = searchParams?.query || ''
-  const keywords = searchParams?.keywords || []
+  const keywords = searchParams?.keywords || ''
   const providers = searchParams?.providers || ''
   const currentPage = Number(searchParams?.page) || 1
 

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -71,8 +71,7 @@ function getSparQLOfferingQueryString (query, keywords, providers, currentPage, 
 
 function checkKeywordsToFilter (keywords) {
   let getKeywordFilter = ''
-  // I really don't like this check, but the param is returned from the searchParams on the Cataloue page as array or string value (one vs multpile)
-  if (keywords !== '' && keywords.length > 0) {
+  if (keywords !== '') {
     getKeywordFilter = `
       ?asset dcat:keyword ?kw
       FILTER(?kw IN (${getSparQLKeywordFilter(keywords)}))`

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -51,7 +51,7 @@ async function fetchFromCatalogue (sparQLQuery) {
   }
 }
 
-function getSparQLOfferingQueryString (query, currentPage, batchSize = settings.batchSize) {
+function getSparQLOfferingQueryString (query, keywords, providers, currentPage, batchSize = settings.batchSize) {
   const offset = (currentPage - 1) * batchSize
   const baseString = `
     ${prefixes}
@@ -59,6 +59,8 @@ function getSparQLOfferingQueryString (query, currentPage, batchSize = settings.
     SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?created
     WHERE {
       ${getOfferingQueryFilter(query)}
+      ${checkKeywordsToFilter(keywords)}
+      ${checkProvidersToFilter(providers)}
     }
     ORDER BY ?created
     LIMIT ${batchSize}
@@ -67,24 +69,70 @@ function getSparQLOfferingQueryString (query, currentPage, batchSize = settings.
   return encodeURI(baseString)
 }
 
-export async function fetchOfferings (query, currentPage) {
-  const sparQLQuery = getSparQLOfferingQueryString(query, currentPage)
+function checkKeywordsToFilter (keywords) {
+  let getKeywordFilter = ''
+  // I really don't like this check, but the param is returned from the searchParams on the Cataloue page as array or string value (one vs multpile)
+  if (keywords !== '' && keywords.length > 0) {
+    getKeywordFilter = `
+      ?asset dcat:keyword ?kw
+      FILTER(?kw IN (${getSparQLKeywordFilter(keywords)}))`
+  }
+  return getKeywordFilter
+}
+
+function checkProvidersToFilter (providers) {
+  let getProviderFilter = ''
+  if (providers !== '') {
+    getProviderFilter = `
+    FILTER(str(?publisher) IN (${getSparQLProviderFilter(providers)}))`
+  }
+  return getProviderFilter
+}
+
+function getSparQLKeywordFilter (keywords) {
+  if (Array.isArray(keywords)) {
+    const arrayLanguageTagged = []
+    keywords.forEach(element => {
+      arrayLanguageTagged.push('"' + element + '"' + '@en')
+    })
+    return arrayLanguageTagged
+  } else {
+    return '"' + keywords + '"' + '@en'
+  }
+}
+
+function getSparQLProviderFilter (providers) {
+  if (Array.isArray(providers)) {
+    const arrayFormatted = []
+    providers.forEach(element => {
+      arrayFormatted.push('"' + element + '"')
+    })
+    return arrayFormatted
+  } else {
+    return '"' + providers + '"'
+  }
+}
+
+export async function fetchOfferings (query, keywords, providers, currentPage) {
+  const sparQLQuery = getSparQLOfferingQueryString(query, keywords, providers, currentPage)
   return fetchFromCatalogue(sparQLQuery)
 }
 
-function getSparQLOfferingsCountQueryString (query = '') {
+function getSparQLOfferingsCountQueryString (query = '', keywords, providers) {
   const baseString = `
   ${prefixes}
   SELECT DISTINCT (COUNT(?offering) as ?count)
   WHERE {
     ${getOfferingQueryFilter(query)}
+    ${checkKeywordsToFilter(keywords)}
+    ${checkProvidersToFilter(providers)}
   }
   `
   return encodeURI(baseString)
 }
 
-export async function fetchOfferingsCount (query) {
-  const sparQLQuery = getSparQLOfferingsCountQueryString(query)
+export async function fetchOfferingsCount (query, keywords, providers) {
+  const sparQLQuery = getSparQLOfferingsCountQueryString(query, keywords, providers)
   const data = await fetchFromCatalogue(sparQLQuery)
   return data[0]?.count.value
 }


### PR DESCRIPTION
# 📃Description
Reworked **Side Bar** component in _Catalogue_ page is here! 


This PR overhauls the `Side Bar` component to work using the real Catalogue. This made some significant changes on the `catalogue.js` service, as now is required always to use on the **SPARQL** the values obtained (if present) from the `SearchParams`.

These values are `keywords` & `providers`

# Dependencies
N/A

# 🔑Key Features
### New Querys requiring keywords & providers 

To filter correctly by these values + calculating correctly the pagination.



## :steam_locomotive: Next Steps
???

## 💡Ideas for future
- Create a new way to handle the "reset filters", i don't like the current one

# 🔒 Issues to close
- #40 
- #39 
# :muscle: Please review and provide feedback or suggestions for further improvements.