### PR TITLE
maint: update flowbite and improve copy button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "dayjs": "^1.11.13",
-        "flowbite-react": "^0.7.2",
+        "flowbite-react": "^0.10.2",
         "formik": "^2.4.6",
         "next": "^14.1.4",
         "react": "^18.2.0",
@@ -31,18 +31,6 @@
         "postcss": "8.4.21",
         "standard": "^17.0.0",
         "tailwindcss": "3.2.4"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -174,32 +162,41 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.6.tgz",
+      "integrity": "sha512-Vkvsw6EcpMHjvZZdMkSY+djMGFbt7CRssW99Ne8tar2WLnZ/l3dbxeTShbLQj+/s35h+Qb4cmnob+EzwtjrXGQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.6"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
-      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom/node_modules/@floating-ui/core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.10.tgz",
-      "integrity": "sha512-sh6f9gVvWQdEzLObrWbJ97c0clJObiALsFe0LiR/kb3tDRKwEhObASEH2QyfdoO/ZBPzwxa9j+nYFo+sqgbioA==",
+      "version": "0.26.21",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.21.tgz",
+      "integrity": "sha512-7P5ncDIiYd6RrwpCDbKyFzvabM014QlzlumtDbK3Bck0UueC+Rp8BLS34qcGBcN1pZCTodl4QNnCVmKv4tSxfQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.0.0",
-        "@floating-ui/utils": "^0.2.0",
+        "@floating-ui/react-dom": "^2.1.1",
+        "@floating-ui/utils": "^0.2.6",
         "tabbable": "^6.0.0"
       },
       "peerDependencies": {
@@ -208,12 +205,12 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.2"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -221,9 +218,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
     "node_modules/@heroicons/react": {
@@ -617,6 +614,73 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+      "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -664,9 +728,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.5",
@@ -716,6 +778,12 @@
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "license": "MIT"
     },
     "node_modules/@types/scheduler": {
       "version": "0.23.0",
@@ -1811,9 +1879,9 @@
       "license": "MIT"
     },
     "node_modules/debounce": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.0.0.tgz",
-      "integrity": "sha512-xRetU6gL1VJbs85Mc4FoEGSjQxzpdxRyFhe3lmWFyy2EzydIcD4xzUvRJMD+NPDfMwKNhxa3PvsIOU32luIWeA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.1.0.tgz",
+      "integrity": "sha512-OkL3+0pPWCqoBc/nhO9u6TIQNTK44fnBnzuVtJAbp13Naxw9R6u21x+8tVTka87AhDZ3htqZ2pSSsZl9fqL2Wg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2885,6 +2953,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3018,28 +3092,39 @@
       "license": "ISC"
     },
     "node_modules/flowbite": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-2.3.0.tgz",
-      "integrity": "sha512-pm3JRo8OIJHGfFYWgaGpPv8E+UdWy0Z3gEAGufw+G/1dusaU/P1zoBLiQpf2/+bYAi+GBQtPVG86KYlV0W+AFQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/flowbite/-/flowbite-2.5.1.tgz",
+      "integrity": "sha512-7jP1jy9c3QP7y+KU9lc8ueMkTyUdMDvRP+lteSWgY5TigSZjf9K1kqZxmqjhbx2gBnFQxMl1GAjVThCa8cEpKA==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.9.3",
+        "flowbite-datepicker": "^1.3.0",
         "mini-svg-data-uri": "^1.4.3"
       }
     },
-    "node_modules/flowbite-react": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/flowbite-react/-/flowbite-react-0.7.8.tgz",
-      "integrity": "sha512-hYYPvIixokNgAlPbmxNAYFLlLi61z492v8hj1jQHykhuesPGTifDFeQcDxKgQvENqc4bRdBdjrKOvnq7D+pm7g==",
+    "node_modules/flowbite-datepicker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/flowbite-datepicker/-/flowbite-datepicker-1.3.2.tgz",
+      "integrity": "sha512-6Nfm0MCVX3mpaR7YSCjmEO2GO8CDt6CX8ZpQnGdeu03WUCWtEPQ/uy0PUiNtIJjJZWnX0Cm3H55MOhbD1g+E/g==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "1.6.0",
-        "@floating-ui/react": "0.26.10",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "flowbite": "^2.0.0"
+      }
+    },
+    "node_modules/flowbite-react": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/flowbite-react/-/flowbite-react-0.10.2.tgz",
+      "integrity": "sha512-qkayK6IFmfH7zuuDnHmS0hJxLtL0KpW4vo4i/VQfZ6ZfaNlUsNLQxCGcmXwbZZtUm2WVw8x71aaDOAxftG9tmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "1.6.6",
+        "@floating-ui/react": "0.26.21",
         "classnames": "2.5.1",
-        "debounce": "2.0.0",
-        "flowbite": "2.3.0",
-        "react-icons": "5.0.1",
-        "tailwind-merge": "2.2.2"
+        "debounce": "2.1.0",
+        "flowbite": "2.5.1",
+        "react-icons": "5.2.1",
+        "tailwind-merge": "2.4.0"
       },
       "peerDependencies": {
         "react": ">=18",
@@ -3754,6 +3839,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "license": "MIT"
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
@@ -5022,9 +5113,9 @@
       "license": "MIT"
     },
     "node_modules/react-icons": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
@@ -5122,12 +5213,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",
@@ -5943,13 +6028,10 @@
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.2.2.tgz",
-      "integrity": "sha512-tWANXsnmJzgw6mQ07nE3aCDkCK4QdT3ThPMCzawoYA2Pws7vSTCvz3Vrjg61jVUGfFZPJzxEP+NimbcW+EdaDw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.4.0.tgz",
+      "integrity": "sha512-49AwoOQNKdqKPd9CViyH5wJoSKsCDjUlzL8DxuGp3P1FsGY36NJDAa18jLZcaHAUUuTj+JB8IAo8zWgBNvBF7A==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.0"
-      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "dayjs": "^1.11.13",
-    "flowbite-react": "^0.7.2",
+    "flowbite-react": "^0.10.2",
     "formik": "^2.4.6",
     "next": "^14.1.4",
     "react": "^18.2.0",

--- a/src/app/dashboard/contracts/components/TransferModal.jsx
+++ b/src/app/dashboard/contracts/components/TransferModal.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { ClipboardWithIcon, Modal, Button, Label, TextInput, Spinner } from 'flowbite-react'
-import { HiPlay, HiCloudUpload, HiCloudDownload, HiClipboardCopy } from 'react-icons/hi'
+import { HiPlay, HiCloudUpload, HiCloudDownload } from 'react-icons/hi'
 import { Formik, Form, Field, ErrorMessage } from 'formik'
 import * as yup from 'yup'
 
@@ -94,14 +94,6 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
     setLoadingPull(false)
     setAuthorization('')
     setEndpoint('')
-  }
-
-  const copyToClipboard = async (text) => {
-    try {
-      await navigator.clipboard.writeText(text)
-    } catch (err) {
-      console.error('Failed to copy!', err)
-    }
   }
 
   return (

--- a/src/app/dashboard/contracts/components/TransferModal.jsx
+++ b/src/app/dashboard/contracts/components/TransferModal.jsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Modal, Button, Label, TextInput, Spinner } from 'flowbite-react'
+import { ClipboardWithIcon, Modal, Button, Label, TextInput, Spinner } from 'flowbite-react'
 import { HiPlay, HiCloudUpload, HiCloudDownload, HiClipboardCopy } from 'react-icons/hi'
 import { Formik, Form, Field, ErrorMessage } from 'formik'
 import * as yup from 'yup'
@@ -170,44 +170,43 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
             {(authorization || endpoint) && (
               <div className='space-y-4 mt-4'>
                 <div>
-                  <Label htmlFor='authorization' value='Authorization Token' />
-                  <div className='flex items-center rounded-lg border border-gray-300 bg-white text-sm text-gray-900 focus-within:ring-2 focus-within:ring-blue-500'>
-                    <input
-                      type='text'
-                      readOnly
-                      id='authorization'
-                      value={authorization}
-                      className='flex-1 bg-transparent border-none focus:ring-0 focus:outline-none px-3 py-2'
-                    />
-                    <button
-                      type='button'
-                      onClick={() => copyToClipboard(authorization)}
-                      className='p-2 hover:bg-gray-300 rounded-r-lg border-l border-gray-300'
-                      title='Copy to clipboard'
-                    >
-                      <HiClipboardCopy size={16} className='text-gray-700' />
-                    </button>
+                  <Label htmlFor='endpoint' value='Endpoint URL' />
+                  <div className='w-full'>
+                    <div className='relative'>
+                      <div className='block w-full rounded-lg border border-gray-300 bg-white text-sm text-gray-900 focus-within:ring-2 focus-within:ring-blue-500'>
+                        <input
+                          type='text'
+                          readOnly
+                          id='endpoint'
+                          value={endpoint}
+                          className='bg-transparent border-none focus:ring-0 focus:outline-none px-3 py-2 w-full'
+                        />
+                        <ClipboardWithIcon
+                          className='absolute right-2 top-1/2 transform -translate-y-1/2 cursor-pointer text-gray-700 bg-white'
+                          valueToCopy={endpoint}
+                        />
+                      </div>
+                    </div>
                   </div>
                 </div>
-
                 <div>
-                  <Label htmlFor='endpoint' value='Endpoint URL' />
-                  <div className='flex items-center rounded-lg border border-gray-300 bg-white text-sm text-gray-900 focus-within:ring-2 focus-within:ring-blue-500'>
-                    <input
-                      type='text'
-                      readOnly
-                      id='endpoint'
-                      value={endpoint}
-                      className='flex-1 bg-transparent border-none focus:ring-0 focus:outline-none px-3 py-2'
-                    />
-                    <button
-                      type='button'
-                      onClick={() => copyToClipboard(endpoint)}
-                      className='p-2 hover:bg-gray-300 rounded-r-lg border-l border-gray-300'
-                      title='Copy to clipboard'
-                    >
-                      <HiClipboardCopy size={16} className='text-gray-700' />
-                    </button>
+                  <Label htmlFor='authorization' value='Authorization Token' />
+                  <div className='w-full'>
+                    <div className='relative'>
+                      <div className='block w-full rounded-lg border border-gray-300 bg-white text-sm text-gray-900 focus-within:ring-2 focus-within:ring-blue-500'>
+                        <input
+                          type='text'
+                          readOnly
+                          id='authorization'
+                          value={authorization}
+                          className='bg-transparent border-none focus:ring-0 focus:outline-none px-3 py-2 w-full'
+                        />
+                        <ClipboardWithIcon
+                          className='absolute right-2 top-1/2 transform -translate-y-1/2 cursor-pointer text-gray-700 bg-white'
+                          valueToCopy={authorization}
+                        />
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,11 @@
+const flowbite = require('flowbite-react/tailwind')
+
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     './src/**/*.{js,ts,jsx,tsx,mdx}',
-    './node_modules/flowbite-react/lib/esm/**/*.js',
-    './node_modules/react-tailwindcss-datepicker/dist/index.esm.js'
+    './node_modules/react-tailwindcss-datepicker/dist/index.esm.js',
+    flowbite.content()
   ],
   theme: {
     extend: {
@@ -43,7 +46,7 @@ module.exports = {
 
   },
   plugins: [
-    require('flowbite/plugin'),
+    flowbite.plugin(),
     require('@tailwindcss/forms')
   ]
 }


### PR DESCRIPTION
Hi there! This small PR builds on top of #75 : it updates flowbite-react to 0.10.2 so we can leverage their [clipboard button](https://flowbite-react.com/docs/components/clipboard#input-with-copy-button). It applies the latter to the transfer modal.

Remember to run `npm install` to reflect the update of flowbite-react, otherwise you'll have surprises in the UI! The way flowbite integrates into nextjs changed a bit (see 77307576938c ).