### PR TITLE
Error Message on push & pull

### DIFF
--- a/src/app/dashboard/contracts/components/TransferModal.jsx
+++ b/src/app/dashboard/contracts/components/TransferModal.jsx
@@ -12,6 +12,7 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
   const [loadingPull, setLoadingPull] = useState(false)
   const [authorization, setAuthorization] = useState('')
   const [endpoint, setEndpoint] = useState('')
+  const [errorMessage, setErrorMessage] = useState(null)
 
   // Validation schema
   const FormSchema = yup.object().shape({
@@ -38,8 +39,9 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
     })
     if (response.ok) {
       setMessage('Successfully pushed data! Check your data destination.')
+      setErrorMessage(null)
     } else {
-      setMessage('Something went wrong pushing the data.')
+      setErrorMessage('Failed to push data. Please try again.')
     }
   }
 
@@ -60,18 +62,21 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
       const { authorization, endpoint } = await response.json()
       if (!authorization || !endpoint) {
         console.error('Invalid response: missing authorization or endpoint')
+        setErrorMessage('Pull failed: Missing authorization or endpoint.')
         return
       }
       setAuthorization(authorization)
       setEndpoint(endpoint)
     } catch (error) {
       console.error('Error in pullTransfer:', error)
+      setErrorMessage('An error occurred during the pull operation.')
     } finally {
       setLoadingPull(false)
     }
   }
 
   const handleSubmit = (values, { setSubmitting }) => {
+    setErrorMessage(null)
     setMessage(null)
     try {
       pushTransfer(contractAgreementId, counterPartyAddress, connectorId, values.dataDestination)
@@ -81,6 +86,7 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
   }
 
   const HandlePull = () => {
+    setErrorMessage(null)
     try {
       pullTransfer(contractAgreementId, counterPartyAddress, connectorId)
     } catch (e) {
@@ -91,6 +97,7 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
   const handleClose = () => {
     setOpen(false)
     setMessage(null)
+    setErrorMessage(null)
     setLoadingPull(false)
     setAuthorization('')
     setEndpoint('')
@@ -205,7 +212,12 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
             )}
           </div>
         </Modal.Body>
-        <Modal.Footer>
+        <Modal.Footer className='flex flex-col items-start space-y-2'>
+          {errorMessage && (
+            <p className='text-red-600 font-semibold text-sm'>
+              {errorMessage}
+            </p>
+          )}
           <Button onClick={handleClose}>Cancel</Button>
         </Modal.Footer>
       </Modal>

--- a/src/app/dashboard/contracts/components/TransferModal.jsx
+++ b/src/app/dashboard/contracts/components/TransferModal.jsx
@@ -41,7 +41,7 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
       setMessage('Successfully pushed data! Check your data destination.')
       setErrorMessage(null)
     } else {
-      setErrorMessage('Failed to push data. Please try again.')
+      setErrorMessage('Failed to push data. The provider\'s connector, or yours, might be offline. Please check your connector or try again later.')
     }
   }
 
@@ -62,7 +62,7 @@ export default function TransferModal ({ contractAgreementId, counterPartyAddres
       const { authorization, endpoint } = await response.json()
       if (!authorization || !endpoint) {
         console.error('Invalid response: missing authorization or endpoint')
-        setErrorMessage('Pull failed: Missing authorization or endpoint.')
+        setErrorMessage('Failed to get endpoint and token to pull data. The provider\'s connector, or yours, might be offline. Please check your connector or try again later.')
         return
       }
       setAuthorization(authorization)


### PR DESCRIPTION
# 📃Description
Simple Error Message on TransferModal for Contracts

<img width="657" height="613" alt="image" src="https://github.com/user-attachments/assets/d41f2509-d6fd-4826-84e4-54b9dad65f44" />

Quite simple PR, we had already a message for the push action, that would indicate if it was successful or an Error.

Now the error message is independent of this message, as the confirmation for the PUSH is needed, being the only process where "our page" doesn't do anything that is "visible", while the PULL on successful shows the fields `URL` & `Auth token`.

# Dependencies
- Docker to launch the Connectors needed, plus their contracts to be able to see Contracts with PULL/PUSH.

# 🔑Key Features
### Independent Error Message
Quite self explanatory! And simple.

## 💡Ideas for future
N/A

# 🔒 Issues to close
- #87  
# :muscle: Please review and provide feedback or suggestions for further improvements.