### PR TITLE
97 integrate profile webserver into the marketplace

### DIFF
--- a/src/app/api/webserver/route.js
+++ b/src/app/api/webserver/route.js
@@ -1,0 +1,17 @@
+import { handleApiRequest } from '@/utils/helpers/handleApiRequest'
+import { submitUserData } from '@/utils/webserver'
+import { NextResponse } from 'next/server'
+
+export async function POST (request) {
+  return handleApiRequest(async () => {
+    const body = await request.json()
+    const response = await submitUserData(body)
+    if (response.error) {
+      return NextResponse.json(
+        { error: response.error },
+        { status: 500 }
+      )
+    }
+    return NextResponse.json(response)
+  }, 'Webserver Submit UserInfo')
+}

--- a/src/app/onboarding/components/OnboardingForm.jsx
+++ b/src/app/onboarding/components/OnboardingForm.jsx
@@ -52,9 +52,40 @@ export default function FormSteps () {
   const { completeRegistration } = useRegistration()
   const [loading, setLoading] = useState(false)
   const submitID = async (values) => {
-    console.log('Requesting ID to DLT Booth...')
+    // Hijacking this method for identity + webserver. If any of 2 fails, we should not try to continue, right?
+    // Added throw errors to stop future executions in case of errors.
     setLoading(true)
+    setError(null)
 
+    // ---- 1. Submit user details to the webserver ----
+    try {
+      const webserverRes = await fetch('/api/webserver', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          first_name: values.first_name,
+          last_name: values.last_name,
+          company_name: values.company,
+          website: values.website,
+          image_url: values.picture
+        })
+      })
+
+      const webserverData = await webserverRes.json()
+
+      if (!webserverRes.ok || webserverData?.error) {
+        throw new Error(webserverData?.error || 'Failed to submit user data')
+      }
+    } catch (err) {
+      console.error('Webserver error:', err)
+      setError({ message: 'Failed to submit user data to the webserver.' })
+      setLoading(false)
+      return
+    }
+
+    // ---- 2. Request ID from DLT Booth ----
     try {
       const response = await fetch('/api/identity', {
         method: 'POST',
@@ -65,16 +96,15 @@ export default function FormSteps () {
       })
 
       const idResp = await response.json()
-      console.log('ID Response:')
-      console.log(idResp)
 
-      if (idResp?.error) {
-        setError(idResp.error)
-      } else {
-        setIdentity(idResp)
-        completeRegistration(idResp)
-        handleNext()
+      if (!response.ok || idResp?.error) {
+        throw new Error(idResp?.error || 'Failed to get identity')
       }
+
+      console.log('ID Response:', idResp)
+      setIdentity(idResp)
+      completeRegistration(idResp)
+      handleNext()
     } catch (error) {
       console.error('Error calling identity API:', error)
       setError({ message: error.message || 'Failed to connect to server' })
@@ -82,6 +112,7 @@ export default function FormSteps () {
       setLoading(false)
     }
   }
+
   const handleModalClose = () => {
     setError(null)
     setOpenModal(false)

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -21,7 +21,9 @@ const settings = {
   contractsPageSize: 5,
   connectorUrl: process.env.CONNECTOR_URL,
   connectorApiKey: process.env.CONNECTOR_API_KEY,
-  maxRetriesGetEDR: process.env.MAX_RETRIES_GET_EDR ?? 5
+  maxRetriesGetEDR: process.env.MAX_RETRIES_GET_EDR ?? 5,
+  webserverUrl: process.env.WEBSERVER_URL,
+  webserverToken: process.env.WEBSERVER_TOKEN
 }
 Object.freeze(settings)
 

--- a/src/utils/webserver.js
+++ b/src/utils/webserver.js
@@ -16,7 +16,7 @@ import { fetchData } from '@/utils/helpers/fetchData'
 export async function submitUserData (userData) {
   const url = `${settings.webserverUrl}/protected`
   const options = {
-    method: 'POST',
+    method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       Authorization: 'Bearer ' + settings.webserverToken // Added as ENV, change if necessary.

--- a/src/utils/webserver.js
+++ b/src/utils/webserver.js
@@ -1,0 +1,35 @@
+import settings from '@/utils/settings'
+import { fetchData } from '@/utils/helpers/fetchData'
+
+/**
+ * Submits user data from the onboarding form to the /protected endpoint.
+ *
+ * @async
+ * @param {Object} userData - The user data to submit.
+ * @param {string} userData.first_name - First name of the user.
+ * @param {string} userData.last_name - Last name of the user.
+ * @param {string} userData.company_name - Company name.
+ * @param {string} userData.website - User's website URL.
+ * @param {string} userData.image_url - URL to the user's image/avatar.
+ * @returns {Object} - The response JSON or an error object.
+ */
+export async function submitUserData (userData) {
+  const url = `${settings.webserverUrl}/protected`
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer ' + settings.webserverToken // Added as ENV, change if necessary.
+    },
+    body: JSON.stringify(userData)
+  }
+
+  try {
+    const response = await fetchData(url, options).then(res => res.json())
+    return response
+  } catch (error) {
+    console.log('Error on submitUserData!')
+    console.log(error)
+    return { error }
+  }
+}


### PR DESCRIPTION
# 📃Description
Integrating the new component webserver into the onboarding form.

As the User Details are stored on premise, this PR handles contacting to the new component webserver (simple API to CRUD this data).

The only thing that may need rewritting is the logic itself of the onboarding process. Thing is, this new functionality and the 
already DLT identity ID are handled on the "step 2" of the `onboarding form`.

I decided that, as the webserver is quite simple and its default action will be to `PUT` this data, first try to contact the webserver THEN does the DLT ID.

If any of these two fails, the user can't "continue" with the steps, but there is the possibilty that the webserver does a `200`, but the DLT **not**.

So in that case, the webserver will "update" its value, even when there was an error on the onboarding (like nothing I could do, at max I could `PUT` the values again on empty in case the DLT functionality fails...)
#### At the same time, this probably will need changes whenever UC updates its Offering Manager and the Manager starts to interact with other SEDI components.

# 🗃️ Dependencies
- Docker to launch the [Webserver](https://github.com/Sedimark/profile/tree/master) component.
- Update your `env.local`!

```
export WEBSERVER_URL="http://localhost:3005"
export WEBSERVER_TOKEN="whateverPassYouPassedOnTheProfileWebServerDocker"
```

# 🔑Key Features
### New API route 
Basically evading problems with ENV server side things.

### Step 2 of the onboarding process triggers the `PUT`.
With the error handling commented above. Basically added `throw error` in both fetch, with its own `try...catch` block to handle errors.
## :steam_locomotive: Next Steps
- Obtain the data from the webserver whenever is necessary.

## 💡Ideas for future
N/A

# 🔒 Issues to close
- #97
# :muscle: Please review and provide feedback or suggestions for further improvements.

## ⚠️ Be aware that you need to CURL the webserver once the form is tested, as we don't show the UserDetails anywhere currently!