### PR TITLE
fix: ci docker image push

### DIFF
--- a/.github/workflows/build_push_docker_image.yaml
+++ b/.github/workflows/build_push_docker_image.yaml
@@ -52,4 +52,5 @@ jobs:
           path: .
           debug: true
           registry: ghcr.io
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_push_docker_image.yaml
+++ b/.github/workflows/build_push_docker_image.yaml
@@ -45,6 +45,8 @@ jobs:
       - name: Kaniko build & push
         uses: aevea/action-kaniko@master
         with:
+          # image name is empty because of Github namespace, which prefixes the image name with
+          # `sedimark/marketplace-frontend`. See https://github.com/aevea/action-kaniko?tab=readme-ov-file#ghcrio
           image: ""
           tag: development
           path: .

--- a/.github/workflows/build_push_docker_image.yaml
+++ b/.github/workflows/build_push_docker_image.yaml
@@ -7,6 +7,9 @@ on:
       - '**'
       - '!main'
 
+permissions:
+  packages: write
+
 jobs:
   build-and-push:
     runs-on: self-hosted

--- a/.github/workflows/build_push_docker_image.yaml
+++ b/.github/workflows/build_push_docker_image.yaml
@@ -49,6 +49,6 @@ jobs:
           tag: development
           path: .
           debug: true
-          registry: containers.HOSTNAME
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_push_docker_image.yaml
+++ b/.github/workflows/build_push_docker_image.yaml
@@ -36,6 +36,10 @@ jobs:
           echo "CATALOGUE_URL=${{ secrets.CATALOGUE_URL }}" > .env.production
           echo "RECOMMENDER_URL=${{ secrets.RECOMMENDER_URL }}" >> .env.production
           echo "BROKER_URL=${{ secrets.BROKER_URL }}" >> .env.production
+          echo "DLT_BOOTH_URL=${{ secrets.DLT_BOOTH_URL }}" >> .env.production
+          echo "CONNECTOR_URL=${{ secrets.CONNECTOR_URL }}" >> .env.production
+          echo "CONNECTOR_API_KEY=${{ secrets.CONNECTOR_API_KEY }}" >> .env.production
+          echo "OFFERING_MANAGER_URL=${{ secrets.OFFERING_MANAGER_URL }}" >> .env.production
 
       - name: Kaniko build & push
         uses: aevea/action-kaniko@master

--- a/.github/workflows/build_push_docker_image.yaml
+++ b/.github/workflows/build_push_docker_image.yaml
@@ -40,8 +40,7 @@ jobs:
       - name: Kaniko build & push
         uses: aevea/action-kaniko@master
         with:
-          image: marketplace-frontend
-          cache: "true"
+          image: sedimark/marketplace-frontend
           tag: development
           path: .
           debug: true

--- a/.github/workflows/build_push_docker_image.yaml
+++ b/.github/workflows/build_push_docker_image.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Kaniko build & push
         uses: aevea/action-kaniko@master
         with:
-          image: sedimark/marketplace-frontend
+          image: ""
           tag: development
           path: .
           debug: true

--- a/.github/workflows/build_push_docker_image.yaml
+++ b/.github/workflows/build_push_docker_image.yaml
@@ -7,13 +7,11 @@ on:
       - '**'
       - '!main'
 
-permissions:
-  packages: write
-
 jobs:
   build-and-push:
     runs-on: self-hosted
     permissions:
+      contents: read
       packages: write
 
     steps:
@@ -51,6 +49,6 @@ jobs:
           tag: development
           path: .
           debug: true
-          registry: ghcr.io
+          registry: containers.HOSTNAME
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi there! This small PR updates our CI job with the following:
- fix the path to the docker image to push in the Github package registry
- add the missing secrets following recent updates

The corresponding secrets have been added to the present repository. Note however that `CONNECTOR_URL` and `OFFERING_MANAGER` have no significance _so far_, since these two components have not yet been deployed in our cluster.

Contributes to #100 
