### PR TITLE
feat: update catalogue and did resolution for profile

### DIFF
--- a/src/app/catalogue/[offeringId]/components/Asset.jsx
+++ b/src/app/catalogue/[offeringId]/components/Asset.jsx
@@ -7,11 +7,9 @@ import settings from '@/utils/settings'
 function Asset ({ offering }) {
   const title = offering.title.value
   const imageUrl = offering?.picture?.value
-  const shortDescription = offering.description.value
   const keywords = offering?.keywords?.value ? offering.keywords.value.split(settings.keywordsSeparator) : []
-  const createdAt = new Date(offering.created.value)
-  const updatedAt = new Date(offering?.updated?.value ?? offering.created.value)
-  const location = offering?.location?.value ?? 'London'
+  const createdAt = new Date(offering.issued.value)
+  const location = offering?.location?.value
   const description = offering.description.value
   return (
     <div className='flex flex-col bg-sedimark-light-blue'>
@@ -22,17 +20,14 @@ function Asset ({ offering }) {
       <div className='flex justify-between m-6 ml-0'>
         <div className='flex flex-row flex-wrap gap-4'>
           <div className='flex flex-row items-center gap-2'>
-            <HiLocationMarker />
-            <p>{location}</p>
-          </div>
-          <div className='flex flex-row items-center gap-2'>
             <HiCalendar />
             <p>Published {createdAt.toISOString().split('T')[0]}</p>
           </div>
-          <div className='flex flex-row items-center gap-2'>
-            <HiOutlineRefresh />
-            <p>Updated {updatedAt.toISOString().split('T')[0]}</p>
-          </div>
+          {location &&
+            <div className='flex flex-row items-center gap-2'>
+              <HiLocationMarker />
+              <p>{location}</p>
+            </div>}
           {offering.license &&
             <div className='flex flex-row items-center gap-2'>
               <HiOutlineScale />
@@ -47,9 +42,6 @@ function Asset ({ offering }) {
         <h5 className='text-xl tracking-tight text-black dark:text-white mb-2'>
           {title}
         </h5>
-        <p className='font-normal text-gray-700 dark:text-gray-400'>
-          {shortDescription}
-        </p>
         <p className='font-normal text-gray-700 dark:text-gray-400'>
           {description}
         </p>

--- a/src/app/catalogue/[offeringId]/components/Asset.jsx
+++ b/src/app/catalogue/[offeringId]/components/Asset.jsx
@@ -1,16 +1,18 @@
 import { Badge } from 'flowbite-react'
 import Image from 'next/image'
-import { HiOutlineScale, HiLocationMarker, HiCalendar, HiOutlineRefresh } from 'react-icons/hi'
+import { HiLocationMarker, HiCalendar, HiUser } from 'react-icons/hi'
 import Credentials from './Credentials'
 import settings from '@/utils/settings'
 
 function Asset ({ offering }) {
   const title = offering.title.value
+  const createdAt = new Date(offering.issued.value)
+  const description = offering?.description?.value
   const imageUrl = offering?.picture?.value
   const keywords = offering?.keywords?.value ? offering.keywords.value.split(settings.keywordsSeparator) : []
-  const createdAt = new Date(offering.issued.value)
   const location = offering?.location?.value
-  const description = offering.description.value
+  const license = offering?.license?.value || 'No license specified'
+  const creator = offering?.creator?.value
   return (
     <div className='flex flex-col bg-sedimark-light-blue'>
       <h5 className='text-3xl font-bold tracking-tight text-black dark:text-white'>
@@ -28,10 +30,10 @@ function Asset ({ offering }) {
               <HiLocationMarker />
               <p>{location}</p>
             </div>}
-          {offering.license &&
+          {creator &&
             <div className='flex flex-row items-center gap-2'>
-              <HiOutlineScale />
-              <p>{offering.license.value}</p>
+              <HiUser />
+              <p>{creator}</p>
             </div>}
         </div>
       </div>
@@ -39,12 +41,13 @@ function Asset ({ offering }) {
       <div className='bg-sedimark-light-blue'>
         {imageUrl &&
           <Image src={imageUrl} alt={title} width={224} height={224} className='float-left mr-5 max-w-56 max-h-56 min-w-16 min-h-16 rounded-sm shadow-md' />}
-        <h5 className='text-xl tracking-tight text-black dark:text-white mb-2'>
-          {title}
-        </h5>
-        <p className='font-normal text-gray-700 dark:text-gray-400'>
+        <p className='font-normal text-gray-700 dark:text-gray-400 min-h-[6rem]'>
           {description}
         </p>
+        <div className='flex flex-row items-center gap-2 mt-3'>
+          <h4 className='text-lg font-bold text-center ml-0'>License:</h4>
+          <p>{license}</p>
+        </div>
         {keywords.length > 0 &&
           <div className='flex items-center flex-wrap'>
             <h4 className='text-lg font-bold text-center m-3 ml-0'>Keywords:</h4>
@@ -55,7 +58,8 @@ function Asset ({ offering }) {
             })}
           </div>}
       </div>
-      <Credentials offering={offering} />
+      {/* TODO: replace by some display of policies */}
+      {/* <Credentials offering={offering} /> */}
     </div>
   )
 }

--- a/src/app/catalogue/[offeringId]/components/ProviderCard.jsx
+++ b/src/app/catalogue/[offeringId]/components/ProviderCard.jsx
@@ -1,5 +1,5 @@
 import Image from 'next/image'
-import { HiMail, HiGlobeAlt, HiUser } from 'react-icons/hi'
+import { HiMail, HiGlobeAlt, HiOfficeBuilding, HiUser } from 'react-icons/hi'
 
 function ProviderCard ({ provider }) {
   return (
@@ -7,27 +7,32 @@ function ProviderCard ({ provider }) {
       <h5 className='text-xl font-bold'>Provided by</h5>
       <div className='flex flex-wrap m-5 ml-0'>
         <div className='float-left mr-5'>
-          {provider?.image &&
-            <Image width={96} height={96} src={provider.image.value} alt={provider.participant.value} className='object-cover object-center rounded-lg shadow-lg' />}
+          {provider?.image_url &&
+            <Image width={96} height={96} src={provider.image_url} alt={provider.alternate_name} className='object-cover object-center rounded-lg shadow-lg' />}
         </div>
         <div className='flex flex-col justify-around'>
           <p className='text-md text-black font-bold'>
-            {provider.accountId.value + ' ( ' + provider.participant.value + ' )'}
+            {provider.alternate_name + ' ( ' + provider.did + ' )'}
           </p>
-          {provider?.givenName && provider?.familyName &&
+          {provider?.first_name && provider?.last_name &&
             <div className='flex items-center gap-2'>
               <HiUser size={20} />
-              <p>{provider.givenName.value + ' ' + provider.familyName.value}</p>
+              <p>{provider.first_name + ' ' + provider.last_name.toUpperCase()}</p>
             </div>}
           {provider?.email &&
             <div className='flex items-center gap-2'>
               <HiMail size={20} />
               <a href={provider.email.value}>{provider.email.value.split(':')[1]}</a>
             </div>}
-          {provider?.homepage &&
+          {provider?.company_name &&
+            <div className='flex items-center gap-2'>
+              <HiOfficeBuilding size={20} />
+              <p>{provider.company_name}</p>
+            </div>}
+          {provider?.website &&
             <div className='flex items-center gap-2'>
               <HiGlobeAlt size={20} />
-              <a href={provider.homepage.value} target='_blank' rel='noreferrer'>{provider.homepage.value}</a>
+              <a href={provider.website} target='_blank' rel='noreferrer'>{provider.website}</a>
             </div>}
         </div>
       </div>

--- a/src/app/catalogue/[offeringId]/components/Recommender.jsx
+++ b/src/app/catalogue/[offeringId]/components/Recommender.jsx
@@ -14,7 +14,7 @@ async function Recommender ({ query }) {
           <div className='flex gap-4 overflow-x-auto p-4 w-full'>
             {recommendations.map((recommendation, index) => {
               return (
-                <Link key={`${recommendation.title.value}-${recommendation.created.value}-${index + 1}`} href={`/catalogue/${btoa(recommendation.offering.value)}`}>
+                <Link key={`${recommendation.title.value}-${recommendation.issued.value}-${index + 1}`} href={`/catalogue/${btoa(recommendation.offering.value)}`}>
                   <RecommenderItem
                     vc={recommendation}
                     providerName={recommendation.publisher.value}

--- a/src/app/catalogue/[offeringId]/components/RecommenderItem.jsx
+++ b/src/app/catalogue/[offeringId]/components/RecommenderItem.jsx
@@ -5,7 +5,7 @@ function RecommenderItem ({ vc, providerName, color }) {
   const maxLengthDescription = 60
   const name = vc.title.value.length > maxLengthTitle ? vc.title.value.substring(0, maxLengthTitle) + '...' : vc.title.value
   const description = vc.description.value.length > maxLengthDescription ? vc.description.value.substring(0, maxLengthDescription) + '...' : vc.description.value
-  const issuanceDate = vc.created.value ? new Date(vc.created.value) : new Date()
+  const issuanceDate = vc.issued.value ? new Date(vc.issued.value) : new Date()
   const date = isNaN(issuanceDate.getTime()) ? new Date() : issuanceDate
   const providedBy = providerName ?? 'OTHER'
   return (

--- a/src/app/catalogue/[offeringId]/page.js
+++ b/src/app/catalogue/[offeringId]/page.js
@@ -3,12 +3,16 @@ import DatasetInfoComponent from './components/DatasetInfoComponent'
 import Recommender from './components/Recommender'
 import { fetchOfferingDetails, fetchProvider } from '@/utils/catalogue'
 import { fetchSimilarRecommendations } from '@/utils/recommender'
+import { getProviderData } from '@/utils/selectedOffering'
 
 export default async function Page ({ params }) {
   const { offeringId } = params
   const offeringIdDecoded = atob(decodeURIComponent(offeringId))
   const offering = await fetchOfferingDetails(offeringIdDecoded)
-  const provider = await fetchProvider(offering.publisher.value)
+  let provider = await getProviderData(offering.publisher.value)
+  // Replacing the alternateName with the one from the offering since we are sure to 
+  // have it (unlike the provider's profile server)
+  provider.alternate_name = offering.alternateName.value
   const recommendations = await fetchSimilarRecommendations(offeringIdDecoded, 5)
 
   return (

--- a/src/app/catalogue/[offeringId]/page.js
+++ b/src/app/catalogue/[offeringId]/page.js
@@ -1,7 +1,7 @@
 import BackToSearchButton from './components/BackToSearchButton'
 import DatasetInfoComponent from './components/DatasetInfoComponent'
 import Recommender from './components/Recommender'
-import { fetchOfferingDetails, fetchProvider } from '@/utils/catalogue'
+import { fetchOfferingDetails } from '@/utils/catalogue'
 import { fetchSimilarRecommendations } from '@/utils/recommender'
 import { getProviderData } from '@/utils/selectedOffering'
 

--- a/src/app/catalogue/components/OfferingItem.jsx
+++ b/src/app/catalogue/components/OfferingItem.jsx
@@ -3,7 +3,7 @@ import { HiOutlineScale, HiCalendar, HiUser } from 'react-icons/hi'
 function OfferingItem ({ offering, color }) {
   const name = offering.title.value
   const description = offering.description.value
-  const issuanceDate = offering.created.value ? new Date(offering.created.value) : new Date()
+  const issuanceDate = offering.issued.value ? new Date(offering.issued.value) : new Date()
   const date = isNaN(issuanceDate.getTime()) ? new Date() : issuanceDate
   return (
     <div className={`flex flex-col p-4 rounded-lg shadow-lg ${color} hover:bg-gray-100`}>
@@ -19,14 +19,9 @@ function OfferingItem ({ offering, color }) {
         <div className='flex flex-row gap-4'>
           <div className='flex flex-row items-center gap-2'>
             <HiUser size={20} />
-            <p className='pr-2'>{offering.publisher.value}</p>
+            <p className='pr-2'>{`${offering.alternateName.value} (${offering.publisher.value})`}</p>
           </div>
         </div>
-        {offering.license &&
-          <div className='flex flex-row items-center gap-2 w-36'>
-            <HiOutlineScale size={20} />
-            <p>{offering.license.value}</p>
-          </div>}
       </div>
     </div>
   )

--- a/src/app/catalogue/components/ResultsList.js
+++ b/src/app/catalogue/components/ResultsList.js
@@ -45,7 +45,7 @@ export default async function ResultsList ({ query, keywords, providers, current
           <div className='flex flex-col w-full gap-4 p-4 bg-gray-50'>
             {data.map((offering, index) => {
               return (
-                <Link key={`${offering.offering.value}-${offering.created.value}-${index + 1}`} href={`catalogue/${btoa(offering.offering.value)}`}>
+                <Link key={`${offering.offering.value}-${offering.issued.value}-${index + 1}`} href={`catalogue/${btoa(offering.offering.value)}`}>
                   <OfferingItem
                     offering={offering}
                     color='bg-gray-50'

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -232,18 +232,13 @@ export async function fetchOfferingDetails (offeringId) {
   const sparQLQuery = `
     ${prefixes}
 
-    SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?alternateName ?issued ?keywords ?license
+    SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?alternateName ?issued ?license (group_concat(?kw; separator=";") as ?keywords)
     WHERE { GRAPH ?g {
       ${offeringsData}
+      OPTIONAL { ?asset dcat:keyword ?kw }
       FILTER(?offering IN (<${offeringId}>))
-      OPTIONAL {
-         SELECT ?asset (group_concat(?kw; separator="${settings.keywordsSeparator}") as ?keywords)
-         WHERE {
-           ?asset dcat:keyword ?kw
-        }
-        GROUP BY ?asset
-      }
     }}
+    GROUP BY ?offering ?asset ?title ?description ?publisher ?alternateName ?creator ?issued ?license
   `
   const offering = await fetchFromCatalogue(sparQLQuery)
   return offering[0]

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -248,25 +248,3 @@ export async function fetchOfferingDetails (offeringId) {
   const offering = await fetchFromCatalogue(sparQLQuery)
   return offering[0]
 }
-
-export async function fetchProvider (providerId) {
-  const sparQLQuery = `
-    ${prefixes}
-
-    SELECT DISTINCT ?participant ?familyName ?givenName ?alternateName ?email ?accountId ?memberOf ?homepage ?image
-    WHERE { GRAPH ?g {
-      ?participant a sedi:Participant .
-      OPTIONAL { ?participant schema:givenName ?givenName . } .
-      OPTIONAL { ?participant schema:familyName ?familyName . } .
-      OPTIONAL { ?participant schema:alternateName ?alternateName . } .
-      OPTIONAL { ?participant schema:email ?email . } .
-      OPTIONAL { ?participant schema:accountId ?accountId . } .
-      OPTIONAL { ?participant schema:memberOf ?memberOf . } .
-      OPTIONAL { ?participant schema:image ?image . } .
-      OPTIONAL { ?participant foaf:homepage ?homepage . } .
-      FILTER(?participant IN (<${providerId}>))
-    }}
-  `
-  const provider = await fetchFromCatalogue(sparQLQuery)
-  return provider[0]
-}

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -20,14 +20,12 @@ const offeringsData = `
     ?offering a sedi:Offering .
     ?offering sedi:hasAsset ?asset .
     ?offering dct:title ?title .
-    ?offering dct:description ?description .
-    ?offering dct:license ?license .
-    ?offering dct:creator ?creator .
+    OPTIONAL { ?offering dct:description ?description . }
     ?offering sedi:isListedBy ?listing .
     ?listing sedi:belongsTo ?participant .
     ?participant schema:accountId ?publisher .
     ?participant schema:alternateName ?alternateName .
-    ?asset dct:issued ?issued .
+    OPTIONAL { ?asset dct:issued ?issued . }
 `
 
 function getOfferingQueryFilter (query) {
@@ -67,7 +65,7 @@ function getSparQLOfferingQueryString (query, keywords, providers, currentPage, 
   const baseString = `
     ${prefixes}
 
-    SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?alternateName ?creator ?issued ?license
+    SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?alternateName ?issued
     WHERE { GRAPH ?g {
       ${getOfferingQueryFilter(query)}
       ${checkKeywordsToFilter(keywords)}
@@ -232,9 +230,11 @@ export async function fetchOfferingDetails (offeringId) {
   const sparQLQuery = `
     ${prefixes}
 
-    SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?alternateName ?issued ?license (group_concat(?kw; separator=";") as ?keywords)
+    SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?alternateName ?creator ?issued ?license (group_concat(?kw; separator=";") as ?keywords)
     WHERE { GRAPH ?g {
       ${offeringsData}
+      OPTIONAL { ?offering dct:license ?license . }
+      OPTIONAL { ?offering dct:creator ?creator . }
       OPTIONAL { ?asset dcat:keyword ?kw }
       FILTER(?offering IN (<${offeringId}>))
     }}

--- a/src/utils/dlt.js
+++ b/src/utils/dlt.js
@@ -80,7 +80,9 @@ export async function resolveDID (did) {
       Accept: 'application/json'
     }
   }
-  const url = `${settings.dltBoothUrl}/dids/${did}`
+
+  const params = new URLSearchParams({did: did})
+  const url = `${settings.dltBoothUrl}/api/dids?${params.toString()}`
 
   try {
     const data = await fetchData(url, options).then(response => response.json())

--- a/src/utils/selectedOffering.js
+++ b/src/utils/selectedOffering.js
@@ -1,0 +1,29 @@
+import { resolveDID } from './dlt.js'
+import { getUserData } from './webserver.js'
+
+export async function getProviderData ( did ) {
+  const didDoc = await resolveDID(did)
+  if (didDoc.error) {
+    console.log(`Error resolving DID ${did}:`, didDoc.error)
+    return { did }
+  }
+
+  if (!didDoc.data || !didDoc.data.service) {
+    console.log(`No service found in DID document for ${did}`)
+    return { did }
+  }
+
+  const profileSvc = didDoc.data.service.find(svc => svc.id.endsWith('profile'));
+  if (!profileSvc || !profileSvc.serviceEndpoint) {
+    console.log(`No profile service found in DID document for ${did}`)
+    return { did }
+  }
+
+  const profile = await getUserData(profileSvc.serviceEndpoint)
+  if (profile.error) {
+    console.log(`Error fetching profile for DID ${did}:`, profile.error)
+    return { did }
+  }
+
+  return {did, ...profile}
+}

--- a/src/utils/webserver.js
+++ b/src/utils/webserver.js
@@ -34,3 +34,28 @@ export async function submitUserData (userData) {
     return { error }
   }
 }
+
+/**
+ * Gets the profile data of a user, given its server URL.
+ *
+ * @async
+ * @param {string} profileUrl - URL of the endpoint to get profile data from.
+ * @returns {Object} - The response JSON or an error object.
+ */
+export async function getUserData (profileUrl = `${settings.webserverUrl}/profile`) {
+  const options = {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }
+
+  try {
+    const response = await fetchData(profileUrl, options).then(res => res.json())
+    return response
+  } catch (error) {
+    console.log('Error on getUserData!')
+    console.log(error)
+    return { error }
+  }
+}


### PR DESCRIPTION
## Description

Hi there! This PR integrates the recent changes done in the offering ontology to query them in the catalogue, and fixes the selected offering page by getting the provider's info from her/his profile server. It also performs minor things:

- many offering attributes are now declared as optional in the sparql query, to avoid not returning offerings when an optional field is missing
- in `fetchOfferingDetails`, getting the keywords wasn't working properly: on `main`, it actually fetches _all_ keywords in the catalogue, not only the ones associated with the offerings. This is fixed here.
- small reworking of the selected offering page to remove non-existing offering attributes and add new ones.

## How to test

You can use the uc.sedimark.eu catalogue, but an easier testing, a catalogue has been set and populated in the Sedimark cluster. You can test the added functionalities in this PR by doing the following:
- port forward to the catalogue in the Sedimark cluster
- set up a DLT booth instance or port forward to the one in the cluster
- in the catalogue page, when you selected an offering whose provider is _xamEviden_, it should be able to resolve its DID, get the url of its profile server, and then get its data.
