### PR TITLE
fix(#107): recommender update

### DIFF
--- a/src/app/catalogue/[offeringId]/components/Recommender.jsx
+++ b/src/app/catalogue/[offeringId]/components/Recommender.jsx
@@ -16,8 +16,7 @@ async function Recommender ({ query }) {
               return (
                 <Link key={`${recommendation.title.value}-${recommendation.issued.value}-${index + 1}`} href={`/catalogue/${btoa(recommendation.offering.value)}`}>
                   <RecommenderItem
-                    vc={recommendation}
-                    providerName={recommendation.publisher.value}
+                    offering={recommendation}
                     color='bg-sedimark-light-blue bg-red'
                   />
                 </Link>

--- a/src/app/catalogue/[offeringId]/components/RecommenderItem.jsx
+++ b/src/app/catalogue/[offeringId]/components/RecommenderItem.jsx
@@ -1,35 +1,25 @@
-import { HiOutlineScale, HiCalendar, HiUser } from 'react-icons/hi'
+import { HiCalendar, HiUser } from 'react-icons/hi'
 
-function RecommenderItem ({ vc, providerName, color }) {
+function RecommenderItem ({ offering, color }) {
   const maxLengthTitle = 42
   const maxLengthDescription = 60
-  const name = vc.title.value.length > maxLengthTitle ? vc.title.value.substring(0, maxLengthTitle) + '...' : vc.title.value
-  const description = vc.description.value.length > maxLengthDescription ? vc.description.value.substring(0, maxLengthDescription) + '...' : vc.description.value
-  const issuanceDate = vc.issued.value ? new Date(vc.issued.value) : new Date()
+  const name = offering.title.value.length > maxLengthTitle ? offering.title.value.substring(0, maxLengthTitle) + '...' : offering.title.value
+  const description = offering.description.value.length > maxLengthDescription ? offering.description.value.substring(0, maxLengthDescription) + '...' : offering.description.value
+  const issuanceDate = offering.issued.value ? new Date(offering.issued.value) : new Date()
   const date = isNaN(issuanceDate.getTime()) ? new Date() : issuanceDate
-  const providedBy = providerName ?? 'OTHER'
   return (
     <div className={`flex flex-col p-4 rounded-lg shadow-lg ${color} hover:bg-gray-100`}>
       <div className='text-lg font-semibold'>{name}</div>
-      <div className='flex justify-between w-96 h-32 mt-4'>
-        <div className='text-sm mr-4'>{description}</div>
-        <span>
-          <div className='flex flex-row gap-2 w-36 mt-2'>
-            <HiCalendar size={20} />
-            <p className='text-sm'>{date.toISOString().split('T')[0]}</p>
-          </div>
-          {vc.license &&
-            <div className='flex flex-row items-center gap-2 w-36'>
-              <HiOutlineScale size={20} />
-              <p>{vc.license.value}</p>
-            </div>}
-        </span>
-      </div>
+      <div className='flex justify-between w-96 h-32 mt-4 text-sm mr-4'>{description}</div>
       <div className='flex justify-between'>
         <div className='flex flex-row gap-4'>
           <div className='flex flex-row items-center gap-2'>
             <HiUser size={20} />
-            <p className='pr-2 text-sm'>{providedBy}</p>
+            <p className='pr-2 text-sm'>{offering.alternateName.value}</p>
+          </div>
+          <div className='flex flex-row items-center gap-2'>
+            <HiCalendar size={20} />
+            <p className='text-sm'>{date.toISOString().split('T')[0]}</p>
           </div>
         </div>
       </div>

--- a/src/app/catalogue/[offeringId]/components/RecommenderItem.jsx
+++ b/src/app/catalogue/[offeringId]/components/RecommenderItem.jsx
@@ -4,7 +4,8 @@ function RecommenderItem ({ offering, color }) {
   const maxLengthTitle = 42
   const maxLengthDescription = 60
   const name = offering.title.value.length > maxLengthTitle ? offering.title.value.substring(0, maxLengthTitle) + '...' : offering.title.value
-  const description = offering.description.value.length > maxLengthDescription ? offering.description.value.substring(0, maxLengthDescription) + '...' : offering.description.value
+  const offeringDescription = offering?.description?.value || ''
+  const description = offeringDescription.length > maxLengthDescription ? offeringDescription.substring(0, maxLengthDescription) + '...' : offeringDescription
   const issuanceDate = offering.issued.value ? new Date(offering.issued.value) : new Date()
   const date = isNaN(issuanceDate.getTime()) ? new Date() : issuanceDate
   return (

--- a/src/app/catalogue/components/OfferingItem.jsx
+++ b/src/app/catalogue/components/OfferingItem.jsx
@@ -2,7 +2,7 @@ import { HiCalendar, HiUser } from 'react-icons/hi'
 
 function OfferingItem ({ offering, color }) {
   const name = offering.title.value
-  const description = offering.description.value
+  const description = offering?.description?.value || ''
   const issuanceDate = offering.issued.value ? new Date(offering.issued.value) : new Date()
   const date = isNaN(issuanceDate.getTime()) ? new Date() : issuanceDate
   return (

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -92,7 +92,7 @@ function checkProvidersToFilter (providers) {
   let getProviderFilter = ''
   if (providers !== '' && providers !== undefined) {
     getProviderFilter = `
-    FILTER(str(?publisher) IN (${getSparQLProviderFilter(providers)}))`
+    FILTER(str(?alternateName) IN (${getSparQLProviderFilter(providers)}))`
   }
   return getProviderFilter
 }

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -213,15 +213,16 @@ export async function fetchKeywords (query) {
 }
 
 export async function fetchRecommendedOfferings (offeringIds) {
+  console.log('fetchRecommendedOfferings called with:', offeringIds)
   const idsString = offeringIds.map(id => `<${id}>`).join(', ')
   const sparQLQuery = `
     ${prefixes}
 
-    SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?issued ?license
-    WHERE {
+    SELECT DISTINCT ?offering ?asset ?title ?description ?publisher ?alternateName ?issued ?license
+    WHERE { GRAPH ?g {
       ${offeringsData}
       FILTER(?offering IN (${idsString}))
-    }
+    }}
   `
   return fetchFromCatalogue(sparQLQuery)
 }

--- a/src/utils/catalogue.js
+++ b/src/utils/catalogue.js
@@ -213,7 +213,6 @@ export async function fetchKeywords (query) {
 }
 
 export async function fetchRecommendedOfferings (offeringIds) {
-  console.log('fetchRecommendedOfferings called with:', offeringIds)
   const idsString = offeringIds.map(id => `<${id}>`).join(', ')
   const sparQLQuery = `
     ${prefixes}


### PR DESCRIPTION
## Description

This PR updates the marketplace to adapt to the new recommender, following updates on the offering ontology. The following changes have been made:
- update recommender related functions and components to display recommended offerings ( f1b5920a1199 )
- adapt offering item and recommended item components to deal with non-existent descriptions ( 651e00eb6d2c )

Another fix unrelated to the scope of this PR: filtering by provider in the catalogue was broken because of switching from DID to alternate name in the display. This is fixed in bcea476c39c1 .

## How to test

A new recommender instance has already been deployed in our cluster. You can port forward to it, alongside our catalogue instance, to test the functionalities in this PR. Using the docker compose in the Sedimark/platform repository is also an option.

## Issues

Closes #107 