### PR TITLE
116 add a menu to access the did document

### DIFF
--- a/src/app/identity/components/IdentityCard.jsx
+++ b/src/app/identity/components/IdentityCard.jsx
@@ -1,13 +1,9 @@
 'use client'
-import {
-  Button,
-  Card,
-  Accordion,
-  ClipboardWithIcon
-} from 'flowbite-react'
+
+import { Card, Accordion, ClipboardWithIcon } from 'flowbite-react'
 import { HiExclamationCircle } from 'react-icons/hi'
 
-export default function IdentityCard ({identity, address, error}) {
+export default function IdentityCard ({ identity, address, error }) {
   const hasError = !identity || !address || error
   // Error message block, if identity or address is empty, or really strange error but somehow values filled
   if (hasError) {
@@ -43,16 +39,14 @@ export default function IdentityCard ({identity, address, error}) {
           </div>
         </div>
 
-
-            <p className='mt-4'>Your key is here:</p>
-            <div className='relative flex items-center gap-2 bg-gray-100 rounded-md px-4 py-2'>
-              <code className='text-gray-800 font-mono break-all'>{address}</code>
-              <ClipboardWithIcon
-                className='right-2 top-1/2 transform -translate-y-1/2 cursor-pointer text-gray-700 bg-gray-100'
-                valueToCopy={address}
-              />
-            </div>
-
+        <p className='mt-4'>Your key is here:</p>
+        <div className='relative flex items-center gap-2 bg-gray-100 rounded-md px-4 py-2'>
+          <code className='text-gray-800 font-mono break-all'>{address}</code>
+          <ClipboardWithIcon
+            className='right-2 top-1/2 transform -translate-y-1/2 cursor-pointer text-gray-700 bg-gray-100'
+            valueToCopy={address}
+          />
+        </div>
 
         <Accordion className='mt-4'>
           <Accordion.Panel>

--- a/src/app/identity/components/IdentityCard.jsx
+++ b/src/app/identity/components/IdentityCard.jsx
@@ -1,0 +1,72 @@
+'use client'
+import {
+  Button,
+  Card,
+  Accordion,
+  ClipboardWithIcon
+} from 'flowbite-react'
+import { HiExclamationCircle } from 'react-icons/hi'
+
+export default function IdentityCard ({identity, address, error}) {
+  const hasError = !identity || !address || error
+  // Error message block, if identity or address is empty, or really strange error but somehow values filled
+  if (hasError) {
+    return (
+      <Card className='w-1/2 mt-6 mx-auto border border-red-300 bg-red-50'>
+        <div className='flex items-center text-red-600 bg-red-100 p-4 rounded-lg border border-red-300'>
+          <HiExclamationCircle className='h-6 w-6 mr-3 flex-shrink-0' />
+          <div>
+            <p className='font-bold text-md mb-1'>Error loading identity or address</p>
+            {error && <p className='text-sm mt-1'>{error.message || 'An unknown error occurred.'}</p>}
+            {!identity && <p className='text-sm mt-1'>No identity data available.</p>}
+            {!address && <p className='text-sm mt-1'>No blockchain address found.</p>}
+          </div>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className='w-1/2 mt-6 mx-auto'>
+      <h5 className='mb-2 text-2xl font-bold tracking-tight text-gray-900'>Verifiable credentials</h5>
+      <Card className='mt-6 '>
+        <div className='flex items-center text-yellow-600 bg-yellow-50 p-4 rounded-lg border border-yellow-200'>
+          <HiExclamationCircle className='h-6 w-6 mr-3 flex-shrink-0' />
+          <div>
+            <p className='font-bold text-md mb-1'>You need to get your funds</p>
+            <p>
+              Use your key here:&nbsp;
+              <a href='https://stardust.linksfoundation.com/faucet/l2/' target='_blank' rel='noopener noreferrer' className='text-blue-600 underline'>
+                https://stardust.linksfoundation.com/faucet/l2/
+              </a>
+            </p>
+          </div>
+        </div>
+
+
+            <p className='mt-4'>Your key is here:</p>
+            <div className='relative flex items-center gap-2 bg-gray-100 rounded-md px-4 py-2'>
+              <code className='text-gray-800 font-mono break-all'>{address}</code>
+              <ClipboardWithIcon
+                className='right-2 top-1/2 transform -translate-y-1/2 cursor-pointer text-gray-700 bg-gray-100'
+                valueToCopy={address}
+              />
+            </div>
+
+
+        <Accordion className='mt-4'>
+          <Accordion.Panel>
+            <Accordion.Title>Verifiable Credential</Accordion.Title>
+            <Accordion.Content className='overflow-auto'>
+              <pre>
+                <code>
+                  {JSON.stringify(identity, null, 2)}
+                </code>
+              </pre>
+            </Accordion.Content>
+          </Accordion.Panel>
+        </Accordion>
+      </Card>
+    </Card>
+  )
+}

--- a/src/app/identity/page.js
+++ b/src/app/identity/page.js
@@ -1,0 +1,25 @@
+import { getIdentity, resolveDID } from "@/utils/dlt"
+import IdentityCard from "./components/IdentityCard"
+
+// This disables cache on this page, as in case the DLT booth is unreachable IN ANY MOMENT, it should not use cache data...
+// Thinking realistically tho, one marketplace will not have more than one identity, so we can discuss if re-enabling cache here!
+export const revalidate = 0
+
+export default async function Page () {
+    // This is a copy of what the 3rd step of the onboardingForm does... The ideal thing would be that dlt.js has a method to return directly
+    // the blockhainAccountId or something like that...
+    const identity = await getIdentity()
+    const did = identity?.data?.sub
+    const responseResolvedDID = await resolveDID(did)
+    const vmWithBlockchainId = responseResolvedDID?.data?.verificationMethod?.find((vm) => vm.blockchainAccountId)
+    const blockchainAccountId = vmWithBlockchainId?.blockchainAccountId
+    if (blockchainAccountId) {
+        const [, address] = blockchainAccountId.split('eip155:1:')
+        return (
+            <IdentityCard identity={identity?.data} address={address} error={identity?.error} />
+        )
+      }
+    return (
+        <IdentityCard/>
+    )
+}

--- a/src/app/identity/page.js
+++ b/src/app/identity/page.js
@@ -1,25 +1,25 @@
-import { getIdentity, resolveDID } from "@/utils/dlt"
-import IdentityCard from "./components/IdentityCard"
+import { getIdentity, resolveDID } from '@/utils/dlt'
+import IdentityCard from './components/IdentityCard'
 
 // This disables cache on this page, as in case the DLT booth is unreachable IN ANY MOMENT, it should not use cache data...
 // Thinking realistically tho, one marketplace will not have more than one identity, so we can discuss if re-enabling cache here!
 export const revalidate = 0
 
 export default async function Page () {
-    // This is a copy of what the 3rd step of the onboardingForm does... The ideal thing would be that dlt.js has a method to return directly
-    // the blockhainAccountId or something like that...
-    const identity = await getIdentity()
-    const did = identity?.data?.sub
-    const responseResolvedDID = await resolveDID(did)
-    const vmWithBlockchainId = responseResolvedDID?.data?.verificationMethod?.find((vm) => vm.blockchainAccountId)
-    const blockchainAccountId = vmWithBlockchainId?.blockchainAccountId
-    if (blockchainAccountId) {
-        const [, address] = blockchainAccountId.split('eip155:1:')
-        return (
-            <IdentityCard identity={identity?.data} address={address} error={identity?.error} />
-        )
-      }
+  // This is a copy of what the 3rd step of the onboardingForm does... The ideal thing would be that dlt.js has a method to return directly
+  // the blockhainAccountId or something like that...
+  const identity = await getIdentity()
+  const did = identity?.data?.sub
+  const responseResolvedDID = await resolveDID(did)
+  const vmWithBlockchainId = responseResolvedDID?.data?.verificationMethod?.find((vm) => vm.blockchainAccountId)
+  const blockchainAccountId = vmWithBlockchainId?.blockchainAccountId
+  if (blockchainAccountId) {
+    const [, address] = blockchainAccountId.split('eip155:1:')
     return (
-        <IdentityCard/>
+      <IdentityCard identity={identity?.data} address={address} error={identity?.error} />
     )
+  }
+  return (
+    <IdentityCard />
+  )
 }

--- a/src/components/nav/LogInOutButton.jsx
+++ b/src/components/nav/LogInOutButton.jsx
@@ -63,7 +63,9 @@ export default function LogInOutButton () {
   if (identity?.data) {
     return (
       <div className='flex gap-4 w-25 h-25 items-center'>
-        <Avatar size='md' rounded />
+        <Link href='/identity'>
+          <Avatar size='md' rounded />
+        </Link>
         <p>{identity.data.vc.credentialSubject['schema:alternateName']}</p>
       </div>
     )


### PR DESCRIPTION
# 📃Description
New Identity Page with the blockchain address + faucet link

<img width="1848" height="888" alt="image" src="https://github.com/user-attachments/assets/07ea9644-a6cb-4abc-893c-2eb3ed2bb777" />

# Dependencies

- DLT-booth 
- Profile server (if you register by frontend, not required if using DLT API directly)

# 🔑Key Features
### 🔗 User Avatar has a link to a new page
Quite simple

### 📄 New `Page` Identity
This page is quite the copy of the last step of the `OnboardingForm`, showing the `Identity` of the participant on a JSON format, and its own `BlockchainAddress` (with a copy to clipboard) together with the link to the faucet to add funds to it.

While the page is server side, the whole `IdentityCard` is client side, just because the damm copy button... We could wrap the copybutton... (and why doesn't flowbite do that? its already passing the values to copy as a prop...)

### 🧠 Disabled cache!
See comments on the code! We can really discuss if this is necesary.

### 🛑 Error handling... the hard way

I redid like 3 times this. Thing is, the page is the one that does the calls + operations (the ideal thing would be that the `utils/dlt.js` had the ability to return directly the blockchain address, but ehh).

The error message is capable of showing if error is on the identity, address, or in any kind of strange error that we may miss.

<img width="1851" height="533" alt="image" src="https://github.com/user-attachments/assets/c3bdb06a-7537-4770-a7c9-3ba6e2b0db86" />

_Nice and clean_

## :steam_locomotive: Next Steps
Maybe change the message of the "You need to get your funds" ? 

## 💡Ideas for future
N/A

# 🔒 Issues to close
- #116
# :muscle: Please review and provide feedback or suggestions for further improvements.