### PR TITLE
maint: remove https csp

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -44,6 +44,5 @@ const cspHeader = `
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';
-    upgrade-insecure-requests;
 `
 module.exports = nextConfig


### PR DESCRIPTION
Just a temporary fix to allow UC to use the frontend in their tests, which uses http only services.