### PR TITLE
fix: small fixes for connector contract negotiation

### DIFF
--- a/src/app/api/connector/contractNegotiation/route.js
+++ b/src/app/api/connector/contractNegotiation/route.js
@@ -5,7 +5,7 @@ import { NextResponse } from 'next/server'
 export async function POST (request) {
   return handleApiRequest(async () => {
     const body = await request.json()
-    const response = await contractNegotiationFlow(body.datasetID, body.counterPartyAddress)
+    const response = await contractNegotiationFlow(body.datasetID, body.counterPartyAddress, body.alternateName)
     if (response.error) {
       return NextResponse.json(
         { error: response.error },

--- a/src/app/catalogue/[offeringId]/components/NegotiateCard.jsx
+++ b/src/app/catalogue/[offeringId]/components/NegotiateCard.jsx
@@ -26,7 +26,7 @@ function NegotiateCard ({ offering, provider }) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          datasetID: offering.offering.value,
+          datasetID: offering.asset.value,
           counterPartyAddress: provider.connector_url
         })
       })

--- a/src/app/catalogue/[offeringId]/components/NegotiateCard.jsx
+++ b/src/app/catalogue/[offeringId]/components/NegotiateCard.jsx
@@ -27,7 +27,8 @@ function NegotiateCard ({ offering, provider }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           datasetID: offering.asset.value,
-          counterPartyAddress: provider.connector_url
+          counterPartyAddress: provider.connector_url,
+          alternateName: provider.alternate_name
         })
       })
 

--- a/src/app/dashboard/contracts/page.js
+++ b/src/app/dashboard/contracts/page.js
@@ -3,6 +3,9 @@ import SidebarDashboard from '../components/sidebar/Sidebar'
 import Contracts from './components/Contracts'
 import CustomPagination from './components/CustomPagination'
 
+// DISABLING CACHE for the whole page!
+export const revalidate = 0
+
 export default function Page ({ searchParams }) {
   const currentPage = Number(searchParams?.page) || 1
   const showConsumed = searchParams.showConsumed === undefined || searchParams.showConsumed === 'true'

--- a/src/app/publish/components/PublishForm.jsx
+++ b/src/app/publish/components/PublishForm.jsx
@@ -23,7 +23,7 @@ export default function PublishForm (brokerAssets) {
     keywords: [],
     url: '',
     url_action: 'GET',
-    headers: [{ key: '', value: '' }],
+    headers: [],
     queries: [{
       name: '',
       label: '',

--- a/src/app/publish/components/assetDefinition/AssetForm.jsx
+++ b/src/app/publish/components/assetDefinition/AssetForm.jsx
@@ -25,8 +25,8 @@ const validationSchemaAssetDefinition = yup.lazy(values =>
     url: yup.string().url('Must be a URL').required('URL is required'),
     url_action: yup.string().required().oneOf(['GET']).label('url_action'),
     headers: yup.array().of(yup.object().shape({
-      key: yup.string().required('A Key is required for the Header'),
-      value: yup.string().required('A Value is required for the Header')
+      key: yup.string(),
+      value: yup.string()
     })),
     keywords: yup.array()
       .of(yup.string().trim().required('Each keyword must be non-empty'))

--- a/src/utils/connector.js
+++ b/src/utils/connector.js
@@ -122,7 +122,7 @@ function getTransferStartBody (connectorId, counterPartyAddress, contractId) {
   return body
 }
 
-function getContractNegotiationBody (policyID, counterPartyAddress) {
+function getContractNegotiationBody (policyID, counterPartyAddress, alternateName) {
   const body = {
     '@context': {
       '@vocab': 'https://w3id.org/edc/v0.0.1/ns/'
@@ -134,7 +134,7 @@ function getContractNegotiationBody (policyID, counterPartyAddress) {
       '@context': 'http://www.w3.org/ns/odrl.jsonld',
       '@id': policyID,
       '@type': 'Offer',
-      assigner: 'provider', // ????
+      assigner: alternateName, // ????
       target: 'assetId' // Should be dataset ID? it does even care what you put here :/
     }
   }
@@ -344,9 +344,11 @@ export async function transferPullFlow (connectorId, counterPartyAddress, contra
  * @param {string} counterPartyAddress - The dataspace protocol URL of the provider connector, usually in the form of <base_url>/protocol or <base_url>/api/dsp.
  * @returns empty Response, expected to be a 200.
  */
-export async function contractNegotiation (policyID, counterPartyAddress) {
+export async function contractNegotiation (policyID, counterPartyAddress, alternateName) {
   const url = `${settings.connectorUrl}/api/management/v3/contractnegotiations`
-  const bodyContractNegotiation = getContractNegotiationBody(policyID, counterPartyAddress)
+  const bodyContractNegotiation = getContractNegotiationBody(policyID, counterPartyAddress, alternateName)
+  console.log('Contract negotiation body to be sent:')
+  console.dir(bodyContractNegotiation)
   const options = {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -389,18 +391,22 @@ export async function fetchDataset (datasetID, counterPartyAddress) {
   }
 }
 
-export async function contractNegotiationFlow (datasetID, counterPartyAddress) {
+export async function contractNegotiationFlow (datasetID, counterPartyAddress, alternateName) {
   // FOR TESTING ONLY:
   // ----- START -----
   // datasetID = 'http://localhost:8080/offerings/12967911-624e-4fc4-94dd-7cf02e49c2af/assets/57a2d1ab-325f-431f-86a6-67ba78f3c569'
   // counterPartyAddress = 'http://provider-cp:8282/api/dsp'
   // ----- END -----
   const getDataset = await fetchDataset(datasetID, counterPartyAddress)
+  console.log('Dataset obtained from fetchDataset():')
+  console.dir(getDataset)
   if (getDataset.error) {
     // Return the error immediately so the flow does not continue + error is sent to be shown on toast
     return { error: 'Failed to get the dataset from the connector!' }
   }
-  const getContractNegotiation = await contractNegotiation(getDataset['odrl:hasPolicy']['@id'], counterPartyAddress)
+  const getContractNegotiation = await contractNegotiation(getDataset['odrl:hasPolicy']['@id'], counterPartyAddress, alternateName)
+  console.log('Contract negotiation response from contractNegotiation():')
+  console.dir(getContractNegotiation)
   // maybe add get contract ID on the flow?
   return getContractNegotiation
 }


### PR DESCRIPTION
## Description

Hi there! From our latest test session with UC, this PR adds some necessary fixes for the frontend to run with the connector, especially to allow proper contract negotiation. More precisely, it implements:
- replacing offering ID by asset ID when negotiating contracts ( 9d0465f47c4a5f178cfe019a8e445b201731c9c7 )
- replacing hardcoded `provider` by provider's alternate name in contract negotiation ( d16575516cb839a4da537d34163b276ab2d4e867 )
- disabling cache in contract pages to ensure contracts appear after negotiation ( d16575516cb839a4da537d34163b276ab2d4e867 )

Other unrelated fix:
- make headers optional in publication form ( 615a2b4694974831b56fd54a56a1bbb0d5d596ec )
