### PR TITLE
feat(#130): add scraping from sedimark news in homepage carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "flowbite-react": "^0.10.2",
         "formik": "^2.4.6",
         "next": "^14.1.4",
+        "node-html-parser": "^7.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-jwt": "^1.2.0",
@@ -1529,6 +1530,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1793,6 +1800,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2020,6 +2055,61 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2053,6 +2143,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -3535,6 +3637,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -4462,6 +4573,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.0.1.tgz",
+      "integrity": "sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -4486,6 +4607,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "flowbite-react": "^0.10.2",
     "formik": "^2.4.6",
     "next": "^14.1.4",
+    "node-html-parser": "^7.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-jwt": "^1.2.0",

--- a/src/app/api/news/route.js
+++ b/src/app/api/news/route.js
@@ -3,7 +3,7 @@ import { parse } from 'node-html-parser'
 
 /**
  * Server-side scraper for https://sedimark.eu/news/
- * Returns JSON array: [{ title, text, url }, ...]
+ * Returns JSON array: [{ title, text, image, meta, url }, ...]
  */
 export async function GET () {
   try {
@@ -28,12 +28,10 @@ export async function GET () {
 
     // Get news items by scraping oxy-post divs
     const postEls = root.querySelectorAll('div.oxy-post')
-    console.dir(postEls.length)
     if (postEls && postEls.length > 0) {
       for (const post of postEls.slice(0, maxItems)) {
         const titleEl = post.querySelector('.oxy-post-title')
         const title = titleEl ? (titleEl.text || '').trim() : ''
-        console.dir(title)
 
         const contentEl = post.querySelector('.oxy-post-content')
         const text = contentEl ? (contentEl.text || '').trim().replace(/\s+/g, ' ') : ''
@@ -42,8 +40,16 @@ export async function GET () {
         const href = linkEl ? (linkEl.getAttribute('href') || '') : ''
         const url = resolveUrl(href)
 
+        const metaEl = post.querySelector('.oxy-post-meta')
+        const meta = metaEl ? (metaEl.text || '').trim().replace(/\s+/g, ' ') : ''
+
+        const imageEl = post.querySelector('.oxy-post-image-fixed-ratio')
+        const imageStyle = imageEl.getAttribute('style') || ''
+        const imageMatch = imageStyle.match(/background-image:\s*url\(['"]?(.*?)['"]?\)/i)
+        const image = imageMatch ? imageMatch[1] : ''
+
         if (title) {
-          items.push({ title, text, url })
+          items.push({ title, text, url, meta, image })
         }
       }
     }

--- a/src/app/api/news/route.js
+++ b/src/app/api/news/route.js
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server'
+import { parse } from 'node-html-parser'
+
+/**
+ * Server-side scraper for https://sedimark.eu/news/
+ * Returns JSON array: [{ title, text, url }, ...]
+ */
+export async function GET () {
+  try {
+    const res = await fetch('https://sedimark.eu/news/')
+    if (!res.ok) {
+      throw new Error(`Upstream returned ${res.status}`)
+    }
+    const html = await res.text()
+    const root = parse(html)
+
+    const items = []
+    const maxItems = 6
+
+    // Helper to resolve hrefs
+    const resolveUrl = (href) => {
+      try {
+        return new URL(href, 'https://sedimark.eu').toString()
+      } catch (e) {
+        return href || 'https://sedimark.eu/news/'
+      }
+    }
+
+    // Get news items by scraping oxy-post divs
+    const postEls = root.querySelectorAll('div.oxy-post')
+    console.dir(postEls.length)
+    if (postEls && postEls.length > 0) {
+      for (const post of postEls.slice(0, maxItems)) {
+        const titleEl = post.querySelector('.oxy-post-title')
+        const title = titleEl ? (titleEl.text || '').trim() : ''
+        console.dir(title)
+
+        const contentEl = post.querySelector('.oxy-post-content')
+        const text = contentEl ? (contentEl.text || '').trim().replace(/\s+/g, ' ') : ''
+
+        const linkEl = post.querySelector('.oxy-read-more')
+        const href = linkEl ? (linkEl.getAttribute('href') || '') : ''
+        const url = resolveUrl(href)
+
+        if (title) {
+          items.push({ title, text, url })
+        }
+      }
+    }
+
+    // Ensures at least 1 item 
+    if (items.length === 0) {
+      items.push({
+        title: 'Visit Sedimark News',
+        text: 'See the latest updates at sedimark.eu/news/',
+        url: 'https://sedimark.eu/news/'
+      })
+    }
+
+    return NextResponse.json(items, { status: 200 })
+  } catch (err) {
+    console.error('Error in /api/news:', err)
+    return NextResponse.json({ error: String(err) }, { status: 500 })
+  }
+}

--- a/src/app/api/news/route.js
+++ b/src/app/api/news/route.js
@@ -54,7 +54,7 @@ export async function GET () {
       }
     }
 
-    // Ensures at least 1 item 
+    // Ensures at least 1 item
     if (items.length === 0) {
       items.push({
         title: 'Visit Sedimark News',

--- a/src/components/home/Slideshow.jsx
+++ b/src/components/home/Slideshow.jsx
@@ -35,13 +35,13 @@ const NewsCarousel = (newsList = [], iteration = 0, cards = 1) => {
                 {news.title}
               </h5>
               <div className='grid grid-cols-3 gap-4 items-center'>
-                  <Image
-                    width={500}
-                    height={500}
-                    style={{ objectFit: 'contain' }}
-                    src={news.image || 'https://sedimark.eu/wp-content/uploads/2022/12/all-logo-banner-circle.png'}
-                    alt={news.title}
-                  />
+                <Image
+                  width={500}
+                  height={500}
+                  style={{ objectFit: 'contain' }}
+                  src={news.image || 'https://sedimark.eu/wp-content/uploads/2022/12/all-logo-banner-circle.png'}
+                  alt={news.title}
+                />
                 <div className='col-span-2 flex flex-col w-full items-center justify-between gap-4'>
                   <p className='italic text-sm text-gray-500 dark:text-gray-400'>
                     {news.meta}

--- a/src/components/home/Slideshow.jsx
+++ b/src/components/home/Slideshow.jsx
@@ -2,25 +2,17 @@
 
 import { useState, useEffect } from 'react'
 import { Carousel, Card, Button } from 'flowbite-react'
+import Image from 'next/image'
 
-const NewsCarousel = (newsList = [], iteration = 0, cards = 3) => {
+const NewsCarousel = (newsList = [], iteration = 0, cards = 1) => {
   if (!newsList || newsList.length === 0) {
-    // Return a safe placeholder slide (Flowbite Carousel expects elements with props)
-    return [(
-      <div key='empty' className='absolute top-1/2 w-full flex justify-center'>
-        <div className='w-1/3 px-[72px]'>
-          <Card className='h-full'>
-            <h5 className='text-xl font-bold tracking-tight text-gray-900 dark:text-white'>
-              Visit Sedimark News
-            </h5>
-            <p className='font-normal text-gray-700 dark:text-gray-400'>
-              See the latest updates at sedimark.eu/news/
-            </p>
-            <Button color='gray' size='sm' onClick={() => { window.location.href = 'https://sedimark.eu/news/' }}> Learn More </Button>
-          </Card>
-        </div>
-      </div>
-    )]
+    newsList = [{
+      title: 'Visit Sedimark News',
+      text: 'See the latest updates at sedimark.eu/news/',
+      url: 'https://sedimark.eu/news/',
+      meta: '',
+      image: 'https://sedimark.eu/wp-content/uploads/2022/12/all-logo-banner-circle.png'
+    }]
   }
 
   const page = newsList.slice(0, cards)
@@ -32,20 +24,35 @@ const NewsCarousel = (newsList = [], iteration = 0, cards = 3) => {
 
   return [
     (
-      <div key={iteration} className='absolute top-1/2 w-full flex flex-row text-start'>
+      <div key={iteration} className='absolute top-1/2 w-full flex flex-row justify-center gap-16 text-start'>
         {page.map((news, index) => {
           return (
-            <div key={`${iteration}-${index}`} className='w-1/3 px-[72px]'>
-              <Card className='h-full'>
-                <h5 className='text-xl font-bold tracking-tight text-gray-900 dark:text-white'>
-                  {news.title}
-                </h5>
-                <p className='font-normal text-gray-700 dark:text-gray-400'>
-                  {news.text}
-                </p>
-                <Button color='gray' size='sm' onClick={() => { window.location.href = news.url }}> Learn more </Button>
-              </Card>
-            </div>
+            <Card
+              key={`${iteration}-${index}`}
+              className='w-1/2'
+            >
+              <h5 className='text-center text-xl font-bold tracking-tight text-gray-900 dark:text-white'>
+                {news.title}
+              </h5>
+              <div className='grid grid-cols-3 gap-4 items-center'>
+                  <Image
+                    width={500}
+                    height={500}
+                    style={{ objectFit: 'contain' }}
+                    src={news.image || 'https://sedimark.eu/wp-content/uploads/2022/12/all-logo-banner-circle.png'}
+                    alt={news.title}
+                  />
+                <div className='col-span-2 flex flex-col w-full items-center justify-between gap-4'>
+                  <p className='italic text-sm text-gray-500 dark:text-gray-400'>
+                    {news.meta}
+                  </p>
+                  <p className='font-normal text-gray-700 dark:text-gray-400 max-h-40 overflow-y-auto'>
+                    {news.text}
+                  </p>
+                  <Button className='w-full' color='gray' size='sm' onClick={() => { window.location.href = news.url }}> Learn more </Button>
+                </div>
+              </div>
+            </Card>
           )
         })}
       </div>

--- a/src/components/home/Slideshow.jsx
+++ b/src/components/home/Slideshow.jsx
@@ -1,38 +1,26 @@
 'use client'
 
+import { useState, useEffect } from 'react'
 import { Carousel, Card, Button } from 'flowbite-react'
 
-const tempNews = [
-  {
-    text: 'After the thrilling session that was held at the EBDVF 2024 in Budapest on October 4th, titled "Leveraging Technologies for Data Management to Implement Data Spaces," where around 30 attendees gathered...',
-    title: 'SEDIMARK at the European Big Data Value Forum (EBDVF) 2024',
-    url: 'https://sedimark.eu/sedimark-at-the-european-big-data-value-forum-ebdvf-2024/'
-  },
-  {
-    text: 'After the thrilling session that was held at the EBDVF 2024 in Budapest on October 4th, titled "Leveraging Technologies for Data Management to Implement Data Spaces," where around 30 attendees gathered...',
-    title: 'SEDIMARK at the European Big Data Value Forum (EBDVF) 2024',
-    url: 'https://sedimark.eu/sedimark-at-the-european-big-data-value-forum-ebdvf-2024/'
-  },
-  {
-    text: 'After the thrilling session that was held at the EBDVF 2024 in Budapest on October 4th, titled "Leveraging Technologies for Data Management to Implement Data Spaces," where around 30 attendees gathered...',
-    title: 'SEDIMARK at the European Big Data Value Forum (EBDVF) 2024',
-    url: 'https://sedimark.eu/sedimark-at-the-european-big-data-value-forum-ebdvf-2024/'
-  },
-  {
-    text: 'After the thrilling session that was held at the EBDVF 2024 in Budapest on October 4th, titled "Leveraging Technologies for Data Management to Implement Data Spaces," where around 30 attendees gathered...',
-    title: 'SEDIMARK at the European Big Data Value Forum (EBDVF) 2024',
-    url: 'https://sedimark.eu/sedimark-at-the-european-big-data-value-forum-ebdvf-2024/'
-  },
-  {
-    text: 'After the thrilling session that was held at the EBDVF 2024 in Budapest on October 4th, titled "Leveraging Technologies for Data Management to Implement Data Spaces," where around 30 attendees gathered...',
-    title: 'SEDIMARK at the European Big Data Value Forum (EBDVF) 2024',
-    url: 'https://sedimark.eu/sedimark-at-the-european-big-data-value-forum-ebdvf-2024/'
-  }
-]
-
-const NewsCarousel = (newsList, iteration = 0, cards = 3) => {
-  if (newsList.length === 0) {
-    return ''
+const NewsCarousel = (newsList = [], iteration = 0, cards = 3) => {
+  if (!newsList || newsList.length === 0) {
+    // Return a safe placeholder slide (Flowbite Carousel expects elements with props)
+    return [(
+      <div key='empty' className='absolute top-1/2 w-full flex justify-center'>
+        <div className='w-1/3 px-[72px]'>
+          <Card className='h-full'>
+            <h5 className='text-xl font-bold tracking-tight text-gray-900 dark:text-white'>
+              Visit Sedimark News
+            </h5>
+            <p className='font-normal text-gray-700 dark:text-gray-400'>
+              See the latest updates at sedimark.eu/news/
+            </p>
+            <Button color='gray' size='sm' onClick={() => { window.location.href = 'https://sedimark.eu/news/' }}> Learn More </Button>
+          </Card>
+        </div>
+      </div>
+    )]
   }
 
   const page = newsList.slice(0, cards)
@@ -65,10 +53,34 @@ const NewsCarousel = (newsList, iteration = 0, cards = 3) => {
 }
 
 const Slideshow = () => {
+  const [news, setNews] = useState([])
+
+  useEffect(() => {
+    let mounted = true
+
+    async function loadNews () {
+      try {
+        const res = await fetch('/api/news')
+        if (!res.ok) {
+          throw new Error(`News API returned ${res.status}`)
+        }
+        const items = await res.json()
+        if (mounted && Array.isArray(items) && items.length > 0) {
+          setNews(items)
+        }
+      } catch (error) {
+        console.error('Failed to load news:', error)
+      }
+    }
+
+    loadNews()
+    return () => { mounted = false }
+  }, [])
+
   return (
     <div className="relative h-[650px] bg-[url('/img/sedimark_bk_light-100.jpg')] bg-cover bg-center w-full text-black">
       <Carousel slideInterval={10000} pauseOnHover>
-        {NewsCarousel(tempNews)}
+        {NewsCarousel(news)}
       </Carousel>
     </div>
   )


### PR DESCRIPTION
## Description

Hi there! This PR adds a new api route to scrape news from https://sedimark.eu/news to populate the carousel in the home page, therefore getting rid of the mock data used until now.

## How to test

You'll need to run `npm install` so you get the new dependency (`node-html-parser`).

Two ways to test this PR, after running the app using `npm run dev`:
1. check the homepage at http://localhost:3000 
2. check that you get a proper list of 5 news containing a title, content, list, metadata and image when querying http://localhost:3000/api/news

## Issues

Closes #130 